### PR TITLE
feat: 외부 서비스 래퍼 및 문장추출 기능 구현 (#5,#6,#7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,38 @@
+# RT-Fact MCP Server
+
+검색 기능과 AI 모델을 사용해 팩트 검증 기능을 제공하는 MCP 서버
+
+## 요구사항
+
+- Python 3.13+
+- [Poetry](https://python-poetry.org/)
+
+## 설치
+
+```bash
+# 의존성 설치
+poetry install
+
+# 환경변수 설정
+cp .env.example .env
+# .env 파일에 GEMINI_API_KEY, TAVILY_API_KEY 설정
+```
+
+## 테스트 실행
+
+```bash
+# 전체 테스트
+poetry run pytest
+
+# 특정 테스트 파일
+poetry run pytest tests/graph/nodes_spec.py -v
+
+# E2E 테스트 (실제 API 호출, API 키 필요)
+PYTHONPATH=src poetry run python scripts/test_extraction_e2e.py
+```
+
+## 개발 서버 실행
+
+```bash
+poetry run uvicorn src.main:app --reload
+```

--- a/README.md
+++ b/README.md
@@ -13,9 +13,40 @@
 # 의존성 설치
 poetry install
 
+# pre-commit 훅 설치 (최초 1회)
+poetry run pre-commit install
+poetry run pre-commit install --hook-type commit-msg
+
 # 환경변수 설정
 cp .env.example .env
 # .env 파일에 GEMINI_API_KEY, TAVILY_API_KEY 설정
+```
+
+## 린팅 & 포맷팅
+
+이 프로젝트는 [ruff](https://docs.astral.sh/ruff/)를 사용하며, [pre-commit](https://pre-commit.com/)으로 자동 실행됩니다.
+
+### 자동 실행 (커밋/푸시 시)
+
+| 훅 | 실행 시점 | 동작 |
+|----|----------|------|
+| `ruff` | 커밋 | 린팅 + 자동 수정 |
+| `ruff-format` | 커밋 | 코드 포맷팅 |
+| `commitizen` | 커밋 | 커밋 메시지 검증 |
+| `ruff check .` | 푸시 | 전체 파일 린트 체크 |
+| `ruff format --check .` | 푸시 | 전체 파일 포맷 체크 |
+
+### 수동 실행
+
+```bash
+# 린팅 체크
+poetry run ruff check .
+
+# 린팅 + 자동 수정
+poetry run ruff check --fix .
+
+# 포맷팅
+poetry run ruff format .
 ```
 
 ## 테스트 실행

--- a/poetry.lock
+++ b/poetry.lock
@@ -58,6 +58,18 @@ files = [
 test = ["coverage", "mypy", "pexpect", "ruff", "wheel"]
 
 [[package]]
+name = "cachetools"
+version = "6.2.4"
+description = "Extensible memoizing collections and decorators"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "cachetools-6.2.4-py3-none-any.whl", hash = "sha256:69a7a52634fed8b8bf6e24a050fb60bff1c9bd8f6d24572b99c32d4e71e62a51"},
+    {file = "cachetools-6.2.4.tar.gz", hash = "sha256:82c5c05585e70b6ba2d3ae09ea60b79548872185d2f24ae1f2709d37299fd607"},
+]
+
+[[package]]
 name = "certifi"
 version = "2025.11.12"
 description = "Python package for providing Mozilla's CA Bundle."
@@ -301,6 +313,18 @@ files = [
 ]
 
 [[package]]
+name = "distro"
+version = "1.9.0"
+description = "Distro - an OS platform information API"
+optional = false
+python-versions = ">=3.6"
+groups = ["main"]
+files = [
+    {file = "distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2"},
+    {file = "distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed"},
+]
+
+[[package]]
 name = "fastapi"
 version = "0.128.0"
 description = "FastAPI framework, high performance, easy to learn, fast to code, ready for production"
@@ -334,6 +358,63 @@ files = [
     {file = "filelock-3.20.2-py3-none-any.whl", hash = "sha256:fbba7237d6ea277175a32c54bb71ef814a8546d8601269e1bfc388de333974e8"},
     {file = "filelock-3.20.2.tar.gz", hash = "sha256:a2241ff4ddde2a7cebddf78e39832509cb045d18ec1a09d7248d6bfc6bfbbe64"},
 ]
+
+[[package]]
+name = "google-auth"
+version = "2.46.0"
+description = "Google Authentication Library"
+optional = false
+python-versions = ">=3.7"
+groups = ["main"]
+files = [
+    {file = "google_auth-2.46.0-py3-none-any.whl", hash = "sha256:fa51659c3745cb7024dd073f4ab766222767ea5f7dee2472110eaa03c9dbd2cb"},
+    {file = "google_auth-2.46.0.tar.gz", hash = "sha256:cb04c071a73394a6e3b9e48c1a7f48506001175b33e9679587a0f5320a21a34d"},
+]
+
+[package.dependencies]
+cachetools = ">=2.0.0,<7.0"
+pyasn1-modules = ">=0.2.1"
+requests = {version = ">=2.20.0,<3.0.0", optional = true, markers = "extra == \"requests\""}
+rsa = ">=3.1.4,<5"
+
+[package.extras]
+aiohttp = ["aiohttp (>=3.6.2,<4.0.0)", "requests (>=2.20.0,<3.0.0)"]
+cryptography = ["cryptography (<39.0.0) ; python_version < \"3.8\"", "cryptography (>=38.0.3)"]
+enterprise-cert = ["cryptography", "pyopenssl"]
+pyjwt = ["cryptography (<39.0.0) ; python_version < \"3.8\"", "cryptography (>=38.0.3)", "pyjwt (>=2.0)"]
+pyopenssl = ["cryptography (<39.0.0) ; python_version < \"3.8\"", "cryptography (>=38.0.3)", "pyopenssl (>=20.0.0)"]
+reauth = ["pyu2f (>=0.1.5)"]
+requests = ["requests (>=2.20.0,<3.0.0)"]
+testing = ["aiohttp (<3.10.0)", "aiohttp (>=3.6.2,<4.0.0)", "aioresponses", "cryptography (<39.0.0) ; python_version < \"3.8\"", "cryptography (<39.0.0) ; python_version < \"3.8\"", "cryptography (>=38.0.3)", "cryptography (>=38.0.3)", "flask", "freezegun", "grpcio", "oauth2client", "packaging", "pyjwt (>=2.0)", "pyopenssl (<24.3.0)", "pyopenssl (>=20.0.0)", "pytest", "pytest-asyncio", "pytest-cov", "pytest-localserver", "pyu2f (>=0.1.5)", "requests (>=2.20.0,<3.0.0)", "responses", "urllib3"]
+urllib3 = ["packaging", "urllib3"]
+
+[[package]]
+name = "google-genai"
+version = "1.56.0"
+description = "GenAI Python SDK"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "google_genai-1.56.0-py3-none-any.whl", hash = "sha256:9e6b11e0c105ead229368cb5849a480e4d0185519f8d9f538d61ecfcf193b052"},
+    {file = "google_genai-1.56.0.tar.gz", hash = "sha256:0491af33c375f099777ae207d9621f044e27091fafad4c50e617eba32165e82f"},
+]
+
+[package.dependencies]
+anyio = ">=4.8.0,<5.0.0"
+distro = ">=1.7.0,<2"
+google-auth = {version = ">=2.45.0,<3.0.0", extras = ["requests"]}
+httpx = ">=0.28.1,<1.0.0"
+pydantic = ">=2.9.0,<3.0.0"
+requests = ">=2.28.1,<3.0.0"
+sniffio = "*"
+tenacity = ">=8.2.3,<9.2.0"
+typing-extensions = ">=4.11.0,<5.0.0"
+websockets = ">=13.0.0,<15.1.0"
+
+[package.extras]
+aiohttp = ["aiohttp (<3.13.3)"]
+local-tokenizer = ["protobuf", "sentencepiece (>=0.2.0)"]
 
 [[package]]
 name = "h11"
@@ -947,6 +1028,33 @@ files = [
 wcwidth = "*"
 
 [[package]]
+name = "pyasn1"
+version = "0.6.1"
+description = "Pure-Python implementation of ASN.1 types and DER/BER/CER codecs (X.208)"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "pyasn1-0.6.1-py3-none-any.whl", hash = "sha256:0d632f46f2ba09143da3a8afe9e33fb6f92fa2320ab7e886e2d0f7672af84629"},
+    {file = "pyasn1-0.6.1.tar.gz", hash = "sha256:6f580d2bdd84365380830acf45550f2511469f673cb4a5ae3857a3170128b034"},
+]
+
+[[package]]
+name = "pyasn1-modules"
+version = "0.4.2"
+description = "A collection of ASN.1-based protocols modules"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "pyasn1_modules-0.4.2-py3-none-any.whl", hash = "sha256:29253a9207ce32b64c3ac6600edc75368f98473906e8fd1043bd6b5b1de2c14a"},
+    {file = "pyasn1_modules-0.4.2.tar.gz", hash = "sha256:677091de870a80aae844b1ca6134f54652fa2c8c5a52aa396440ac3106e941e6"},
+]
+
+[package.dependencies]
+pyasn1 = ">=0.6.1,<0.7.0"
+
+[[package]]
 name = "pydantic"
 version = "2.12.5"
 description = "Data validation using Python type hints"
@@ -1290,6 +1398,131 @@ files = [
 prompt_toolkit = ">=2.0,<4.0"
 
 [[package]]
+name = "regex"
+version = "2025.11.3"
+description = "Alternative regular expression module, to replace re."
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "regex-2025.11.3-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:2b441a4ae2c8049106e8b39973bfbddfb25a179dda2bdb99b0eeb60c40a6a3af"},
+    {file = "regex-2025.11.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:2fa2eed3f76677777345d2f81ee89f5de2f5745910e805f7af7386a920fa7313"},
+    {file = "regex-2025.11.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:d8b4a27eebd684319bdf473d39f1d79eed36bf2cd34bd4465cdb4618d82b3d56"},
+    {file = "regex-2025.11.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5cf77eac15bd264986c4a2c63353212c095b40f3affb2bc6b4ef80c4776c1a28"},
+    {file = "regex-2025.11.3-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:b7f9ee819f94c6abfa56ec7b1dbab586f41ebbdc0a57e6524bd5e7f487a878c7"},
+    {file = "regex-2025.11.3-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:838441333bc90b829406d4a03cb4b8bf7656231b84358628b0406d803931ef32"},
+    {file = "regex-2025.11.3-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:cfe6d3f0c9e3b7e8c0c694b24d25e677776f5ca26dce46fd6b0489f9c8339391"},
+    {file = "regex-2025.11.3-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2ab815eb8a96379a27c3b6157fcb127c8f59c36f043c1678110cea492868f1d5"},
+    {file = "regex-2025.11.3-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:728a9d2d173a65b62bdc380b7932dd8e74ed4295279a8fe1021204ce210803e7"},
+    {file = "regex-2025.11.3-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:509dc827f89c15c66a0c216331260d777dd6c81e9a4e4f830e662b0bb296c313"},
+    {file = "regex-2025.11.3-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:849202cd789e5f3cf5dcc7822c34b502181b4824a65ff20ce82da5524e45e8e9"},
+    {file = "regex-2025.11.3-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:b6f78f98741dcc89607c16b1e9426ee46ce4bf31ac5e6b0d40e81c89f3481ea5"},
+    {file = "regex-2025.11.3-cp310-cp310-win32.whl", hash = "sha256:149eb0bba95231fb4f6d37c8f760ec9fa6fabf65bab555e128dde5f2475193ec"},
+    {file = "regex-2025.11.3-cp310-cp310-win_amd64.whl", hash = "sha256:ee3a83ce492074c35a74cc76cf8235d49e77b757193a5365ff86e3f2f93db9fd"},
+    {file = "regex-2025.11.3-cp310-cp310-win_arm64.whl", hash = "sha256:38af559ad934a7b35147716655d4a2f79fcef2d695ddfe06a06ba40ae631fa7e"},
+    {file = "regex-2025.11.3-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:eadade04221641516fa25139273505a1c19f9bf97589a05bc4cfcd8b4a618031"},
+    {file = "regex-2025.11.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:feff9e54ec0dd3833d659257f5c3f5322a12eee58ffa360984b716f8b92983f4"},
+    {file = "regex-2025.11.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:3b30bc921d50365775c09a7ed446359e5c0179e9e2512beec4a60cbcef6ddd50"},
+    {file = "regex-2025.11.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f99be08cfead2020c7ca6e396c13543baea32343b7a9a5780c462e323bd8872f"},
+    {file = "regex-2025.11.3-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:6dd329a1b61c0ee95ba95385fb0c07ea0d3fe1a21e1349fa2bec272636217118"},
+    {file = "regex-2025.11.3-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:4c5238d32f3c5269d9e87be0cf096437b7622b6920f5eac4fd202468aaeb34d2"},
+    {file = "regex-2025.11.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:10483eefbfb0adb18ee9474498c9a32fcf4e594fbca0543bb94c48bac6183e2e"},
+    {file = "regex-2025.11.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:78c2d02bb6e1da0720eedc0bad578049cad3f71050ef8cd065ecc87691bed2b0"},
+    {file = "regex-2025.11.3-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:e6b49cd2aad93a1790ce9cffb18964f6d3a4b0b3dbdbd5de094b65296fce6e58"},
+    {file = "regex-2025.11.3-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:885b26aa3ee56433b630502dc3d36ba78d186a00cc535d3806e6bfd9ed3c70ab"},
+    {file = "regex-2025.11.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ddd76a9f58e6a00f8772e72cff8ebcff78e022be95edf018766707c730593e1e"},
+    {file = "regex-2025.11.3-cp311-cp311-win32.whl", hash = "sha256:3e816cc9aac1cd3cc9a4ec4d860f06d40f994b5c7b4d03b93345f44e08cc68bf"},
+    {file = "regex-2025.11.3-cp311-cp311-win_amd64.whl", hash = "sha256:087511f5c8b7dfbe3a03f5d5ad0c2a33861b1fc387f21f6f60825a44865a385a"},
+    {file = "regex-2025.11.3-cp311-cp311-win_arm64.whl", hash = "sha256:1ff0d190c7f68ae7769cd0313fe45820ba07ffebfddfaa89cc1eb70827ba0ddc"},
+    {file = "regex-2025.11.3-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:bc8ab71e2e31b16e40868a40a69007bc305e1109bd4658eb6cad007e0bf67c41"},
+    {file = "regex-2025.11.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:22b29dda7e1f7062a52359fca6e58e548e28c6686f205e780b02ad8ef710de36"},
+    {file = "regex-2025.11.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:3a91e4a29938bc1a082cc28fdea44be420bf2bebe2665343029723892eb073e1"},
+    {file = "regex-2025.11.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:08b884f4226602ad40c5d55f52bf91a9df30f513864e0054bad40c0e9cf1afb7"},
+    {file = "regex-2025.11.3-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:3e0b11b2b2433d1c39c7c7a30e3f3d0aeeea44c2a8d0bae28f6b95f639927a69"},
+    {file = "regex-2025.11.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:87eb52a81ef58c7ba4d45c3ca74e12aa4b4e77816f72ca25258a85b3ea96cb48"},
+    {file = "regex-2025.11.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a12ab1f5c29b4e93db518f5e3872116b7e9b1646c9f9f426f777b50d44a09e8c"},
+    {file = "regex-2025.11.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:7521684c8c7c4f6e88e35ec89680ee1aa8358d3f09d27dfbdf62c446f5d4c695"},
+    {file = "regex-2025.11.3-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:7fe6e5440584e94cc4b3f5f4d98a25e29ca12dccf8873679a635638349831b98"},
+    {file = "regex-2025.11.3-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:8e026094aa12b43f4fd74576714e987803a315c76edb6b098b9809db5de58f74"},
+    {file = "regex-2025.11.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:435bbad13e57eb5606a68443af62bed3556de2f46deb9f7d4237bc2f1c9fb3a0"},
+    {file = "regex-2025.11.3-cp312-cp312-win32.whl", hash = "sha256:3839967cf4dc4b985e1570fd8d91078f0c519f30491c60f9ac42a8db039be204"},
+    {file = "regex-2025.11.3-cp312-cp312-win_amd64.whl", hash = "sha256:e721d1b46e25c481dc5ded6f4b3f66c897c58d2e8cfdf77bbced84339108b0b9"},
+    {file = "regex-2025.11.3-cp312-cp312-win_arm64.whl", hash = "sha256:64350685ff08b1d3a6fff33f45a9ca183dc1d58bbfe4981604e70ec9801bbc26"},
+    {file = "regex-2025.11.3-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:c1e448051717a334891f2b9a620fe36776ebf3dd8ec46a0b877c8ae69575feb4"},
+    {file = "regex-2025.11.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:9b5aca4d5dfd7fbfbfbdaf44850fcc7709a01146a797536a8f84952e940cca76"},
+    {file = "regex-2025.11.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:04d2765516395cf7dda331a244a3282c0f5ae96075f728629287dfa6f76ba70a"},
+    {file = "regex-2025.11.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5d9903ca42bfeec4cebedba8022a7c97ad2aab22e09573ce9976ba01b65e4361"},
+    {file = "regex-2025.11.3-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:639431bdc89d6429f6721625e8129413980ccd62e9d3f496be618a41d205f160"},
+    {file = "regex-2025.11.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:f117efad42068f9715677c8523ed2be1518116d1c49b1dd17987716695181efe"},
+    {file = "regex-2025.11.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4aecb6f461316adf9f1f0f6a4a1a3d79e045f9b71ec76055a791affa3b285850"},
+    {file = "regex-2025.11.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:3b3a5f320136873cc5561098dfab677eea139521cb9a9e8db98b7e64aef44cbc"},
+    {file = "regex-2025.11.3-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:75fa6f0056e7efb1f42a1c34e58be24072cb9e61a601340cc1196ae92326a4f9"},
+    {file = "regex-2025.11.3-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:dbe6095001465294f13f1adcd3311e50dd84e5a71525f20a10bd16689c61ce0b"},
+    {file = "regex-2025.11.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:454d9b4ae7881afbc25015b8627c16d88a597479b9dea82b8c6e7e2e07240dc7"},
+    {file = "regex-2025.11.3-cp313-cp313-win32.whl", hash = "sha256:28ba4d69171fc6e9896337d4fc63a43660002b7da53fc15ac992abcf3410917c"},
+    {file = "regex-2025.11.3-cp313-cp313-win_amd64.whl", hash = "sha256:bac4200befe50c670c405dc33af26dad5a3b6b255dd6c000d92fe4629f9ed6a5"},
+    {file = "regex-2025.11.3-cp313-cp313-win_arm64.whl", hash = "sha256:2292cd5a90dab247f9abe892ac584cb24f0f54680c73fcb4a7493c66c2bf2467"},
+    {file = "regex-2025.11.3-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:1eb1ebf6822b756c723e09f5186473d93236c06c579d2cc0671a722d2ab14281"},
+    {file = "regex-2025.11.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:1e00ec2970aab10dc5db34af535f21fcf32b4a31d99e34963419636e2f85ae39"},
+    {file = "regex-2025.11.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:a4cb042b615245d5ff9b3794f56be4138b5adc35a4166014d31d1814744148c7"},
+    {file = "regex-2025.11.3-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:44f264d4bf02f3176467d90b294d59bf1db9fe53c141ff772f27a8b456b2a9ed"},
+    {file = "regex-2025.11.3-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7be0277469bf3bd7a34a9c57c1b6a724532a0d235cd0dc4e7f4316f982c28b19"},
+    {file = "regex-2025.11.3-cp313-cp313t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:0d31e08426ff4b5b650f68839f5af51a92a5b51abd8554a60c2fbc7c71f25d0b"},
+    {file = "regex-2025.11.3-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e43586ce5bd28f9f285a6e729466841368c4a0353f6fd08d4ce4630843d3648a"},
+    {file = "regex-2025.11.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:0f9397d561a4c16829d4e6ff75202c1c08b68a3bdbfe29dbfcdb31c9830907c6"},
+    {file = "regex-2025.11.3-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:dd16e78eb18ffdb25ee33a0682d17912e8cc8a770e885aeee95020046128f1ce"},
+    {file = "regex-2025.11.3-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:ffcca5b9efe948ba0661e9df0fa50d2bc4b097c70b9810212d6b62f05d83b2dd"},
+    {file = "regex-2025.11.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:c56b4d162ca2b43318ac671c65bd4d563e841a694ac70e1a976ac38fcf4ca1d2"},
+    {file = "regex-2025.11.3-cp313-cp313t-win32.whl", hash = "sha256:9ddc42e68114e161e51e272f667d640f97e84a2b9ef14b7477c53aac20c2d59a"},
+    {file = "regex-2025.11.3-cp313-cp313t-win_amd64.whl", hash = "sha256:7a7c7fdf755032ffdd72c77e3d8096bdcb0eb92e89e17571a196f03d88b11b3c"},
+    {file = "regex-2025.11.3-cp313-cp313t-win_arm64.whl", hash = "sha256:df9eb838c44f570283712e7cff14c16329a9f0fb19ca492d21d4b7528ee6821e"},
+    {file = "regex-2025.11.3-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:9697a52e57576c83139d7c6f213d64485d3df5bf84807c35fa409e6c970801c6"},
+    {file = "regex-2025.11.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:e18bc3f73bd41243c9b38a6d9f2366cd0e0137a9aebe2d8ff76c5b67d4c0a3f4"},
+    {file = "regex-2025.11.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:61a08bcb0ec14ff4e0ed2044aad948d0659604f824cbd50b55e30b0ec6f09c73"},
+    {file = "regex-2025.11.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c9c30003b9347c24bcc210958c5d167b9e4f9be786cb380a7d32f14f9b84674f"},
+    {file = "regex-2025.11.3-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:4e1e592789704459900728d88d41a46fe3969b82ab62945560a31732ffc19a6d"},
+    {file = "regex-2025.11.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:6538241f45eb5a25aa575dbba1069ad786f68a4f2773a29a2bd3dd1f9de787be"},
+    {file = "regex-2025.11.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bce22519c989bb72a7e6b36a199384c53db7722fe669ba891da75907fe3587db"},
+    {file = "regex-2025.11.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:66d559b21d3640203ab9075797a55165d79017520685fb407b9234d72ab63c62"},
+    {file = "regex-2025.11.3-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:669dcfb2e38f9e8c69507bace46f4889e3abbfd9b0c29719202883c0a603598f"},
+    {file = "regex-2025.11.3-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:32f74f35ff0f25a5021373ac61442edcb150731fbaa28286bbc8bb1582c89d02"},
+    {file = "regex-2025.11.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:e6c7a21dffba883234baefe91bc3388e629779582038f75d2a5be918e250f0ed"},
+    {file = "regex-2025.11.3-cp314-cp314-win32.whl", hash = "sha256:795ea137b1d809eb6836b43748b12634291c0ed55ad50a7d72d21edf1cd565c4"},
+    {file = "regex-2025.11.3-cp314-cp314-win_amd64.whl", hash = "sha256:9f95fbaa0ee1610ec0fc6b26668e9917a582ba80c52cc6d9ada15e30aa9ab9ad"},
+    {file = "regex-2025.11.3-cp314-cp314-win_arm64.whl", hash = "sha256:dfec44d532be4c07088c3de2876130ff0fbeeacaa89a137decbbb5f665855a0f"},
+    {file = "regex-2025.11.3-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:ba0d8a5d7f04f73ee7d01d974d47c5834f8a1b0224390e4fe7c12a3a92a78ecc"},
+    {file = "regex-2025.11.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:442d86cf1cfe4faabf97db7d901ef58347efd004934da045c745e7b5bd57ac49"},
+    {file = "regex-2025.11.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:fd0a5e563c756de210bb964789b5abe4f114dacae9104a47e1a649b910361536"},
+    {file = "regex-2025.11.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bf3490bcbb985a1ae97b2ce9ad1c0f06a852d5b19dde9b07bdf25bf224248c95"},
+    {file = "regex-2025.11.3-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:3809988f0a8b8c9dcc0f92478d6501fac7200b9ec56aecf0ec21f4a2ec4b6009"},
+    {file = "regex-2025.11.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:f4ff94e58e84aedb9c9fce66d4ef9f27a190285b451420f297c9a09f2b9abee9"},
+    {file = "regex-2025.11.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7eb542fd347ce61e1321b0a6b945d5701528dca0cd9759c2e3bb8bd57e47964d"},
+    {file = "regex-2025.11.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:d6c2d5919075a1f2e413c00b056ea0c2f065b3f5fe83c3d07d325ab92dce51d6"},
+    {file = "regex-2025.11.3-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:3f8bf11a4827cc7ce5a53d4ef6cddd5ad25595d3c1435ef08f76825851343154"},
+    {file = "regex-2025.11.3-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:22c12d837298651e5550ac1d964e4ff57c3f56965fc1812c90c9fb2028eaf267"},
+    {file = "regex-2025.11.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:62ba394a3dda9ad41c7c780f60f6e4a70988741415ae96f6d1bf6c239cf01379"},
+    {file = "regex-2025.11.3-cp314-cp314t-win32.whl", hash = "sha256:4bf146dca15cdd53224a1bf46d628bd7590e4a07fbb69e720d561aea43a32b38"},
+    {file = "regex-2025.11.3-cp314-cp314t-win_amd64.whl", hash = "sha256:adad1a1bcf1c9e76346e091d22d23ac54ef28e1365117d99521631078dfec9de"},
+    {file = "regex-2025.11.3-cp314-cp314t-win_arm64.whl", hash = "sha256:c54f768482cef41e219720013cd05933b6f971d9562544d691c68699bf2b6801"},
+    {file = "regex-2025.11.3-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:81519e25707fc076978c6143b81ea3dc853f176895af05bf7ec51effe818aeec"},
+    {file = "regex-2025.11.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:3bf28b1873a8af8bbb58c26cc56ea6e534d80053b41fb511a35795b6de507e6a"},
+    {file = "regex-2025.11.3-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:856a25c73b697f2ce2a24e7968285579e62577a048526161a2c0f53090bea9f9"},
+    {file = "regex-2025.11.3-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8a3d571bd95fade53c86c0517f859477ff3a93c3fde10c9e669086f038e0f207"},
+    {file = "regex-2025.11.3-cp39-cp39-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:732aea6de26051af97b94bc98ed86448821f839d058e5d259c72bf6d73ad0fc0"},
+    {file = "regex-2025.11.3-cp39-cp39-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:51c1c1847128238f54930edb8805b660305dca164645a9fd29243f5610beea34"},
+    {file = "regex-2025.11.3-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:22dd622a402aad4558277305350699b2be14bc59f64d64ae1d928ce7d072dced"},
+    {file = "regex-2025.11.3-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f3b5a391c7597ffa96b41bd5cbd2ed0305f515fcbb367dfa72735679d5502364"},
+    {file = "regex-2025.11.3-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:cc4076a5b4f36d849fd709284b4a3b112326652f3b0466f04002a6c15a0c96c1"},
+    {file = "regex-2025.11.3-cp39-cp39-musllinux_1_2_ppc64le.whl", hash = "sha256:a295ca2bba5c1c885826ce3125fa0b9f702a1be547d821c01d65f199e10c01e2"},
+    {file = "regex-2025.11.3-cp39-cp39-musllinux_1_2_s390x.whl", hash = "sha256:b4774ff32f18e0504bfc4e59a3e71e18d83bc1e171a3c8ed75013958a03b2f14"},
+    {file = "regex-2025.11.3-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:22e7d1cdfa88ef33a2ae6aa0d707f9255eb286ffbd90045f1088246833223aee"},
+    {file = "regex-2025.11.3-cp39-cp39-win32.whl", hash = "sha256:74d04244852ff73b32eeede4f76f51c5bcf44bc3c207bc3e6cf1c5c45b890708"},
+    {file = "regex-2025.11.3-cp39-cp39-win_amd64.whl", hash = "sha256:7a50cd39f73faa34ec18d6720ee25ef10c4c1839514186fcda658a06c06057a2"},
+    {file = "regex-2025.11.3-cp39-cp39-win_arm64.whl", hash = "sha256:43b4fb020e779ca81c1b5255015fe2b82816c76ec982354534ad9ec09ad7c9e3"},
+    {file = "regex-2025.11.3.tar.gz", hash = "sha256:1fedc720f9bb2494ce31a58a1631f9c82df6a09b49c19517ea5cc280b4541e01"},
+]
+
+[[package]]
 name = "requests"
 version = "2.32.5"
 description = "Python HTTP for Humans."
@@ -1327,6 +1560,21 @@ files = [
 requests = ">=2.0.1,<3.0.0"
 
 [[package]]
+name = "rsa"
+version = "4.9.1"
+description = "Pure-Python RSA implementation"
+optional = false
+python-versions = "<4,>=3.6"
+groups = ["main"]
+files = [
+    {file = "rsa-4.9.1-py3-none-any.whl", hash = "sha256:68635866661c6836b8d39430f97a996acbd61bfa49406748ea243539fe239762"},
+    {file = "rsa-4.9.1.tar.gz", hash = "sha256:e7bdbfdb5497da4c07dfd35530e1a902659db6ff241e39d9953cad06ebd0ae75"},
+]
+
+[package.dependencies]
+pyasn1 = ">=0.1.3"
+
+[[package]]
 name = "ruff"
 version = "0.14.10"
 description = "An extremely fast Python linter and code formatter, written in Rust."
@@ -1356,6 +1604,18 @@ files = [
 ]
 
 [[package]]
+name = "sniffio"
+version = "1.3.1"
+description = "Sniff out which async library your code is running under"
+optional = false
+python-versions = ">=3.7"
+groups = ["main"]
+files = [
+    {file = "sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2"},
+    {file = "sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc"},
+]
+
+[[package]]
 name = "starlette"
 version = "0.50.0"
 description = "The little ASGI library that shines."
@@ -1372,6 +1632,23 @@ anyio = ">=3.6.2,<5"
 
 [package.extras]
 full = ["httpx (>=0.27.0,<0.29.0)", "itsdangerous", "jinja2", "python-multipart (>=0.0.18)", "pyyaml"]
+
+[[package]]
+name = "tavily-python"
+version = "0.7.17"
+description = "Python wrapper for the Tavily API"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "tavily_python-0.7.17-py3-none-any.whl", hash = "sha256:a2725b9cba71e404e73d19ff277df916283c10100137c336e07f8e1bd7789fcf"},
+    {file = "tavily_python-0.7.17.tar.gz", hash = "sha256:437ba064639dfdce1acdbc37cbb73246abe500ab735e988a4b8698a8d5fb7df7"},
+]
+
+[package.dependencies]
+httpx = "*"
+requests = "*"
+tiktoken = ">=0.5.1"
 
 [[package]]
 name = "tenacity"
@@ -1403,6 +1680,80 @@ files = [
 
 [package.extras]
 tests = ["pytest", "pytest-cov"]
+
+[[package]]
+name = "tiktoken"
+version = "0.12.0"
+description = "tiktoken is a fast BPE tokeniser for use with OpenAI's models"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "tiktoken-0.12.0-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:3de02f5a491cfd179aec916eddb70331814bd6bf764075d39e21d5862e533970"},
+    {file = "tiktoken-0.12.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:b6cfb6d9b7b54d20af21a912bfe63a2727d9cfa8fbda642fd8322c70340aad16"},
+    {file = "tiktoken-0.12.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:cde24cdb1b8a08368f709124f15b36ab5524aac5fa830cc3fdce9c03d4fb8030"},
+    {file = "tiktoken-0.12.0-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:6de0da39f605992649b9cfa6f84071e3f9ef2cec458d08c5feb1b6f0ff62e134"},
+    {file = "tiktoken-0.12.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:6faa0534e0eefbcafaccb75927a4a380463a2eaa7e26000f0173b920e98b720a"},
+    {file = "tiktoken-0.12.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:82991e04fc860afb933efb63957affc7ad54f83e2216fe7d319007dab1ba5892"},
+    {file = "tiktoken-0.12.0-cp310-cp310-win_amd64.whl", hash = "sha256:6fb2995b487c2e31acf0a9e17647e3b242235a20832642bb7a9d1a181c0c1bb1"},
+    {file = "tiktoken-0.12.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:6e227c7f96925003487c33b1b32265fad2fbcec2b7cf4817afb76d416f40f6bb"},
+    {file = "tiktoken-0.12.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:c06cf0fcc24c2cb2adb5e185c7082a82cba29c17575e828518c2f11a01f445aa"},
+    {file = "tiktoken-0.12.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:f18f249b041851954217e9fd8e5c00b024ab2315ffda5ed77665a05fa91f42dc"},
+    {file = "tiktoken-0.12.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:47a5bc270b8c3db00bb46ece01ef34ad050e364b51d406b6f9730b64ac28eded"},
+    {file = "tiktoken-0.12.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:508fa71810c0efdcd1b898fda574889ee62852989f7c1667414736bcb2b9a4bd"},
+    {file = "tiktoken-0.12.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:a1af81a6c44f008cba48494089dd98cccb8b313f55e961a52f5b222d1e507967"},
+    {file = "tiktoken-0.12.0-cp311-cp311-win_amd64.whl", hash = "sha256:3e68e3e593637b53e56f7237be560f7a394451cb8c11079755e80ae64b9e6def"},
+    {file = "tiktoken-0.12.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:b97f74aca0d78a1ff21b8cd9e9925714c15a9236d6ceacf5c7327c117e6e21e8"},
+    {file = "tiktoken-0.12.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:2b90f5ad190a4bb7c3eb30c5fa32e1e182ca1ca79f05e49b448438c3e225a49b"},
+    {file = "tiktoken-0.12.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:65b26c7a780e2139e73acc193e5c63ac754021f160df919add909c1492c0fb37"},
+    {file = "tiktoken-0.12.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:edde1ec917dfd21c1f2f8046b86348b0f54a2c0547f68149d8600859598769ad"},
+    {file = "tiktoken-0.12.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:35a2f8ddd3824608b3d650a000c1ef71f730d0c56486845705a8248da00f9fe5"},
+    {file = "tiktoken-0.12.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:83d16643edb7fa2c99eff2ab7733508aae1eebb03d5dfc46f5565862810f24e3"},
+    {file = "tiktoken-0.12.0-cp312-cp312-win_amd64.whl", hash = "sha256:ffc5288f34a8bc02e1ea7047b8d041104791d2ddbf42d1e5fa07822cbffe16bd"},
+    {file = "tiktoken-0.12.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:775c2c55de2310cc1bc9a3ad8826761cbdc87770e586fd7b6da7d4589e13dab3"},
+    {file = "tiktoken-0.12.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a01b12f69052fbe4b080a2cfb867c4de12c704b56178edf1d1d7b273561db160"},
+    {file = "tiktoken-0.12.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:01d99484dc93b129cd0964f9d34eee953f2737301f18b3c7257bf368d7615baa"},
+    {file = "tiktoken-0.12.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:4a1a4fcd021f022bfc81904a911d3df0f6543b9e7627b51411da75ff2fe7a1be"},
+    {file = "tiktoken-0.12.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:981a81e39812d57031efdc9ec59fa32b2a5a5524d20d4776574c4b4bd2e9014a"},
+    {file = "tiktoken-0.12.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9baf52f84a3f42eef3ff4e754a0db79a13a27921b457ca9832cf944c6be4f8f3"},
+    {file = "tiktoken-0.12.0-cp313-cp313-win_amd64.whl", hash = "sha256:b8a0cd0c789a61f31bf44851defbd609e8dd1e2c8589c614cc1060940ef1f697"},
+    {file = "tiktoken-0.12.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:d5f89ea5680066b68bcb797ae85219c72916c922ef0fcdd3480c7d2315ffff16"},
+    {file = "tiktoken-0.12.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:b4e7ed1c6a7a8a60a3230965bdedba8cc58f68926b835e519341413370e0399a"},
+    {file = "tiktoken-0.12.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:fc530a28591a2d74bce821d10b418b26a094bf33839e69042a6e86ddb7a7fb27"},
+    {file = "tiktoken-0.12.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:06a9f4f49884139013b138920a4c393aa6556b2f8f536345f11819389c703ebb"},
+    {file = "tiktoken-0.12.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:04f0e6a985d95913cabc96a741c5ffec525a2c72e9df086ff17ebe35985c800e"},
+    {file = "tiktoken-0.12.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:0ee8f9ae00c41770b5f9b0bb1235474768884ae157de3beb5439ca0fd70f3e25"},
+    {file = "tiktoken-0.12.0-cp313-cp313t-win_amd64.whl", hash = "sha256:dc2dd125a62cb2b3d858484d6c614d136b5b848976794edfb63688d539b8b93f"},
+    {file = "tiktoken-0.12.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:a90388128df3b3abeb2bfd1895b0681412a8d7dc644142519e6f0a97c2111646"},
+    {file = "tiktoken-0.12.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:da900aa0ad52247d8794e307d6446bd3cdea8e192769b56276695d34d2c9aa88"},
+    {file = "tiktoken-0.12.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:285ba9d73ea0d6171e7f9407039a290ca77efcdb026be7769dccc01d2c8d7fff"},
+    {file = "tiktoken-0.12.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:d186a5c60c6a0213f04a7a802264083dea1bbde92a2d4c7069e1a56630aef830"},
+    {file = "tiktoken-0.12.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:604831189bd05480f2b885ecd2d1986dc7686f609de48208ebbbddeea071fc0b"},
+    {file = "tiktoken-0.12.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:8f317e8530bb3a222547b85a58583238c8f74fd7a7408305f9f63246d1a0958b"},
+    {file = "tiktoken-0.12.0-cp314-cp314-win_amd64.whl", hash = "sha256:399c3dd672a6406719d84442299a490420b458c44d3ae65516302a99675888f3"},
+    {file = "tiktoken-0.12.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:c2c714c72bc00a38ca969dae79e8266ddec999c7ceccd603cc4f0d04ccd76365"},
+    {file = "tiktoken-0.12.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:cbb9a3ba275165a2cb0f9a83f5d7025afe6b9d0ab01a22b50f0e74fee2ad253e"},
+    {file = "tiktoken-0.12.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:dfdfaa5ffff8993a3af94d1125870b1d27aed7cb97aa7eb8c1cefdbc87dbee63"},
+    {file = "tiktoken-0.12.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:584c3ad3d0c74f5269906eb8a659c8bfc6144a52895d9261cdaf90a0ae5f4de0"},
+    {file = "tiktoken-0.12.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:54c891b416a0e36b8e2045b12b33dd66fb34a4fe7965565f1b482da50da3e86a"},
+    {file = "tiktoken-0.12.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5edb8743b88d5be814b1a8a8854494719080c28faaa1ccbef02e87354fe71ef0"},
+    {file = "tiktoken-0.12.0-cp314-cp314t-win_amd64.whl", hash = "sha256:f61c0aea5565ac82e2ec50a05e02a6c44734e91b51c10510b084ea1b8e633a71"},
+    {file = "tiktoken-0.12.0-cp39-cp39-macosx_10_12_x86_64.whl", hash = "sha256:d51d75a5bffbf26f86554d28e78bfb921eae998edc2675650fd04c7e1f0cdc1e"},
+    {file = "tiktoken-0.12.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:09eb4eae62ae7e4c62364d9ec3a57c62eea707ac9a2b2c5d6bd05de6724ea179"},
+    {file = "tiktoken-0.12.0-cp39-cp39-manylinux_2_28_aarch64.whl", hash = "sha256:df37684ace87d10895acb44b7f447d4700349b12197a526da0d4a4149fde074c"},
+    {file = "tiktoken-0.12.0-cp39-cp39-manylinux_2_28_x86_64.whl", hash = "sha256:4c9614597ac94bb294544345ad8cf30dac2129c05e2db8dc53e082f355857af7"},
+    {file = "tiktoken-0.12.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:20cf97135c9a50de0b157879c3c4accbb29116bcf001283d26e073ff3b345946"},
+    {file = "tiktoken-0.12.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:15d875454bbaa3728be39880ddd11a5a2a9e548c29418b41e8fd8a767172b5ec"},
+    {file = "tiktoken-0.12.0-cp39-cp39-win_amd64.whl", hash = "sha256:2cff3688ba3c639ebe816f8d58ffbbb0aa7433e23e08ab1cade5d175fc973fb3"},
+    {file = "tiktoken-0.12.0.tar.gz", hash = "sha256:b18ba7ee2b093863978fcb14f74b3707cdc8d4d4d3836853ce7ec60772139931"},
+]
+
+[package.dependencies]
+regex = ">=2022.1.18"
+requests = ">=2.26.0"
+
+[package.extras]
+blobfile = ["blobfile (>=2)"]
 
 [[package]]
 name = "tomlkit"
@@ -1543,6 +1894,85 @@ groups = ["dev"]
 files = [
     {file = "wcwidth-0.2.14-py2.py3-none-any.whl", hash = "sha256:a7bb560c8aee30f9957e5f9895805edd20602f2d7f720186dfd906e82b4982e1"},
     {file = "wcwidth-0.2.14.tar.gz", hash = "sha256:4d478375d31bc5395a3c55c40ccdf3354688364cd61c4f6adacaa9215d0b3605"},
+]
+
+[[package]]
+name = "websockets"
+version = "15.0.1"
+description = "An implementation of the WebSocket Protocol (RFC 6455 & 7692)"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "websockets-15.0.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:d63efaa0cd96cf0c5fe4d581521d9fa87744540d4bc999ae6e08595a1014b45b"},
+    {file = "websockets-15.0.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:ac60e3b188ec7574cb761b08d50fcedf9d77f1530352db4eef1707fe9dee7205"},
+    {file = "websockets-15.0.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:5756779642579d902eed757b21b0164cd6fe338506a8083eb58af5c372e39d9a"},
+    {file = "websockets-15.0.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0fdfe3e2a29e4db3659dbd5bbf04560cea53dd9610273917799f1cde46aa725e"},
+    {file = "websockets-15.0.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4c2529b320eb9e35af0fa3016c187dffb84a3ecc572bcee7c3ce302bfeba52bf"},
+    {file = "websockets-15.0.1-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ac1e5c9054fe23226fb11e05a6e630837f074174c4c2f0fe442996112a6de4fb"},
+    {file = "websockets-15.0.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:5df592cd503496351d6dc14f7cdad49f268d8e618f80dce0cd5a36b93c3fc08d"},
+    {file = "websockets-15.0.1-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:0a34631031a8f05657e8e90903e656959234f3a04552259458aac0b0f9ae6fd9"},
+    {file = "websockets-15.0.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:3d00075aa65772e7ce9e990cab3ff1de702aa09be3940d1dc88d5abf1ab8a09c"},
+    {file = "websockets-15.0.1-cp310-cp310-win32.whl", hash = "sha256:1234d4ef35db82f5446dca8e35a7da7964d02c127b095e172e54397fb6a6c256"},
+    {file = "websockets-15.0.1-cp310-cp310-win_amd64.whl", hash = "sha256:39c1fec2c11dc8d89bba6b2bf1556af381611a173ac2b511cf7231622058af41"},
+    {file = "websockets-15.0.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:823c248b690b2fd9303ba00c4f66cd5e2d8c3ba4aa968b2779be9532a4dad431"},
+    {file = "websockets-15.0.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:678999709e68425ae2593acf2e3ebcbcf2e69885a5ee78f9eb80e6e371f1bf57"},
+    {file = "websockets-15.0.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:d50fd1ee42388dcfb2b3676132c78116490976f1300da28eb629272d5d93e905"},
+    {file = "websockets-15.0.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d99e5546bf73dbad5bf3547174cd6cb8ba7273062a23808ffea025ecb1cf8562"},
+    {file = "websockets-15.0.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:66dd88c918e3287efc22409d426c8f729688d89a0c587c88971a0faa2c2f3792"},
+    {file = "websockets-15.0.1-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8dd8327c795b3e3f219760fa603dcae1dcc148172290a8ab15158cf85a953413"},
+    {file = "websockets-15.0.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:8fdc51055e6ff4adeb88d58a11042ec9a5eae317a0a53d12c062c8a8865909e8"},
+    {file = "websockets-15.0.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:693f0192126df6c2327cce3baa7c06f2a117575e32ab2308f7f8216c29d9e2e3"},
+    {file = "websockets-15.0.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:54479983bd5fb469c38f2f5c7e3a24f9a4e70594cd68cd1fa6b9340dadaff7cf"},
+    {file = "websockets-15.0.1-cp311-cp311-win32.whl", hash = "sha256:16b6c1b3e57799b9d38427dda63edcbe4926352c47cf88588c0be4ace18dac85"},
+    {file = "websockets-15.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:27ccee0071a0e75d22cb35849b1db43f2ecd3e161041ac1ee9d2352ddf72f065"},
+    {file = "websockets-15.0.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:3e90baa811a5d73f3ca0bcbf32064d663ed81318ab225ee4f427ad4e26e5aff3"},
+    {file = "websockets-15.0.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:592f1a9fe869c778694f0aa806ba0374e97648ab57936f092fd9d87f8bc03665"},
+    {file = "websockets-15.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0701bc3cfcb9164d04a14b149fd74be7347a530ad3bbf15ab2c678a2cd3dd9a2"},
+    {file = "websockets-15.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e8b56bdcdb4505c8078cb6c7157d9811a85790f2f2b3632c7d1462ab5783d215"},
+    {file = "websockets-15.0.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0af68c55afbd5f07986df82831c7bff04846928ea8d1fd7f30052638788bc9b5"},
+    {file = "websockets-15.0.1-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:64dee438fed052b52e4f98f76c5790513235efaa1ef7f3f2192c392cd7c91b65"},
+    {file = "websockets-15.0.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:d5f6b181bb38171a8ad1d6aa58a67a6aa9d4b38d0f8c5f496b9e42561dfc62fe"},
+    {file = "websockets-15.0.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:5d54b09eba2bada6011aea5375542a157637b91029687eb4fdb2dab11059c1b4"},
+    {file = "websockets-15.0.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3be571a8b5afed347da347bfcf27ba12b069d9d7f42cb8c7028b5e98bbb12597"},
+    {file = "websockets-15.0.1-cp312-cp312-win32.whl", hash = "sha256:c338ffa0520bdb12fbc527265235639fb76e7bc7faafbb93f6ba80d9c06578a9"},
+    {file = "websockets-15.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:fcd5cf9e305d7b8338754470cf69cf81f420459dbae8a3b40cee57417f4614a7"},
+    {file = "websockets-15.0.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:ee443ef070bb3b6ed74514f5efaa37a252af57c90eb33b956d35c8e9c10a1931"},
+    {file = "websockets-15.0.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5a939de6b7b4e18ca683218320fc67ea886038265fd1ed30173f5ce3f8e85675"},
+    {file = "websockets-15.0.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:746ee8dba912cd6fc889a8147168991d50ed70447bf18bcda7039f7d2e3d9151"},
+    {file = "websockets-15.0.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:595b6c3969023ecf9041b2936ac3827e4623bfa3ccf007575f04c5a6aa318c22"},
+    {file = "websockets-15.0.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3c714d2fc58b5ca3e285461a4cc0c9a66bd0e24c5da9911e30158286c9b5be7f"},
+    {file = "websockets-15.0.1-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0f3c1e2ab208db911594ae5b4f79addeb3501604a165019dd221c0bdcabe4db8"},
+    {file = "websockets-15.0.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:229cf1d3ca6c1804400b0a9790dc66528e08a6a1feec0d5040e8b9eb14422375"},
+    {file = "websockets-15.0.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:756c56e867a90fb00177d530dca4b097dd753cde348448a1012ed6c5131f8b7d"},
+    {file = "websockets-15.0.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:558d023b3df0bffe50a04e710bc87742de35060580a293c2a984299ed83bc4e4"},
+    {file = "websockets-15.0.1-cp313-cp313-win32.whl", hash = "sha256:ba9e56e8ceeeedb2e080147ba85ffcd5cd0711b89576b83784d8605a7df455fa"},
+    {file = "websockets-15.0.1-cp313-cp313-win_amd64.whl", hash = "sha256:e09473f095a819042ecb2ab9465aee615bd9c2028e4ef7d933600a8401c79561"},
+    {file = "websockets-15.0.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:5f4c04ead5aed67c8a1a20491d54cdfba5884507a48dd798ecaf13c74c4489f5"},
+    {file = "websockets-15.0.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:abdc0c6c8c648b4805c5eacd131910d2a7f6455dfd3becab248ef108e89ab16a"},
+    {file = "websockets-15.0.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:a625e06551975f4b7ea7102bc43895b90742746797e2e14b70ed61c43a90f09b"},
+    {file = "websockets-15.0.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d591f8de75824cbb7acad4e05d2d710484f15f29d4a915092675ad3456f11770"},
+    {file = "websockets-15.0.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:47819cea040f31d670cc8d324bb6435c6f133b8c7a19ec3d61634e62f8d8f9eb"},
+    {file = "websockets-15.0.1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ac017dd64572e5c3bd01939121e4d16cf30e5d7e110a119399cf3133b63ad054"},
+    {file = "websockets-15.0.1-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:4a9fac8e469d04ce6c25bb2610dc535235bd4aa14996b4e6dbebf5e007eba5ee"},
+    {file = "websockets-15.0.1-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:363c6f671b761efcb30608d24925a382497c12c506b51661883c3e22337265ed"},
+    {file = "websockets-15.0.1-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:2034693ad3097d5355bfdacfffcbd3ef5694f9718ab7f29c29689a9eae841880"},
+    {file = "websockets-15.0.1-cp39-cp39-win32.whl", hash = "sha256:3b1ac0d3e594bf121308112697cf4b32be538fb1444468fb0a6ae4feebc83411"},
+    {file = "websockets-15.0.1-cp39-cp39-win_amd64.whl", hash = "sha256:b7643a03db5c95c799b89b31c036d5f27eeb4d259c798e878d6937d71832b1e4"},
+    {file = "websockets-15.0.1-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:0c9e74d766f2818bb95f84c25be4dea09841ac0f734d1966f415e4edfc4ef1c3"},
+    {file = "websockets-15.0.1-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:1009ee0c7739c08a0cd59de430d6de452a55e42d6b522de7aa15e6f67db0b8e1"},
+    {file = "websockets-15.0.1-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:76d1f20b1c7a2fa82367e04982e708723ba0e7b8d43aa643d3dcd404d74f1475"},
+    {file = "websockets-15.0.1-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f29d80eb9a9263b8d109135351caf568cc3f80b9928bccde535c235de55c22d9"},
+    {file = "websockets-15.0.1-pp310-pypy310_pp73-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b359ed09954d7c18bbc1680f380c7301f92c60bf924171629c5db97febb12f04"},
+    {file = "websockets-15.0.1-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:cad21560da69f4ce7658ca2cb83138fb4cf695a2ba3e475e0559e05991aa8122"},
+    {file = "websockets-15.0.1-pp39-pypy39_pp73-macosx_10_15_x86_64.whl", hash = "sha256:7f493881579c90fc262d9cdbaa05a6b54b3811c2f300766748db79f098db9940"},
+    {file = "websockets-15.0.1-pp39-pypy39_pp73-macosx_11_0_arm64.whl", hash = "sha256:47b099e1f4fbc95b701b6e85768e1fcdaf1630f3cbe4765fa216596f12310e2e"},
+    {file = "websockets-15.0.1-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:67f2b6de947f8c757db2db9c71527933ad0019737ec374a8a6be9a956786aaf9"},
+    {file = "websockets-15.0.1-pp39-pypy39_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d08eb4c2b7d6c41da6ca0600c077e93f5adcfd979cd777d747e9ee624556da4b"},
+    {file = "websockets-15.0.1-pp39-pypy39_pp73-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4b826973a4a2ae47ba357e4e82fa44a463b8f168e1ca775ac64521442b19e87f"},
+    {file = "websockets-15.0.1-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:21c1fa28a6a7e3cbdc171c694398b6df4744613ce9b36b1a498e816787e28123"},
+    {file = "websockets-15.0.1-py3-none-any.whl", hash = "sha256:f7a866fbc1e97b5c617ee4116daaa09b722101d4a3c170c787450ba409f9736f"},
+    {file = "websockets-15.0.1.tar.gz", hash = "sha256:82544de02076bafba038ce055ee6412d68da13ab47f0c60cab827346de828dee"},
 ]
 
 [[package]]
@@ -1930,4 +2360,4 @@ cffi = ["cffi (>=1.17,<2.0) ; platform_python_implementation != \"PyPy\" and pyt
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.13,<4.0"
-content-hash = "8f8a9a5354989105557628552f4d52fdf6882241c8782127d3a2293fa0382b9c"
+content-hash = "902bcde8dcf9935b7c5999f6cb721d1e54a9268345171a18bdc0d4c941224606"

--- a/poetry.lock
+++ b/poetry.lock
@@ -2360,4 +2360,4 @@ cffi = ["cffi (>=1.17,<2.0) ; platform_python_implementation != \"PyPy\" and pyt
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.13,<4.0"
-content-hash = "902bcde8dcf9935b7c5999f6cb721d1e54a9268345171a18bdc0d4c941224606"
+content-hash = "a9032dc6479592ea5104da72bef5836c2b6b32bae5b063ed9856f8d6efa1a3ea"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,9 @@ dependencies = [
     "fastapi (>=0.128.0,<0.129.0)",
     "uvicorn (>=0.40.0,<0.41.0)",
     "python-dotenv (>=1.2.1,<2.0.0)",
-    "langgraph (>=1.0.5,<2.0.0)"
+    "langgraph (>=1.0.5,<2.0.0)",
+    "google-genai (>=1.56.0,<2.0.0)",
+    "tavily-python (>=0.7.17,<0.8.0)"
 ]
 
 [tool.commitizen]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,8 @@ dependencies = [
     "python-dotenv (>=1.2.1,<2.0.0)",
     "langgraph (>=1.0.5,<2.0.0)",
     "google-genai (>=1.56.0,<2.0.0)",
-    "tavily-python (>=0.7.17,<0.8.0)"
+    "tavily-python (>=0.7.17,<0.8.0)",
+    "pydantic (>=2.12.5,<3.0.0)"
 ]
 
 [tool.commitizen]

--- a/scripts/test_extraction_e2e.py
+++ b/scripts/test_extraction_e2e.py
@@ -32,6 +32,16 @@ async def test():
         start = s["startIndex"]
         end = s["endIndex"]
         
+        # -1 인덱스 처리: LLM이 원본에서 문장을 찾지 못한 경우
+        if start == -1:
+            print(f"[{type_str}] {text_str}")
+            print(f"  ⚠️ Sentence not found in original text (index: -1)")
+            if "reason" in s:
+                print(f"  reason: {s['reason']}")
+            print()
+            all_valid = False
+            continue
+        
         # 인덱스 검증: original_text[start:end]가 text와 일치하는지
         extracted = original_text[start:end]
         is_valid = extracted == text_str

--- a/scripts/test_extraction_e2e.py
+++ b/scripts/test_extraction_e2e.py
@@ -1,62 +1,79 @@
 """E2E test for extraction_node with real Gemini API"""
+
 from dotenv import load_dotenv
+
 load_dotenv()
 
-import asyncio
-from graph.nodes.extraction import extraction_node
+import asyncio  # noqa: E402
 
+from graph.nodes.extraction import extraction_node  # noqa: E402
 
 """사용법(터미널): PYTHONPATH=src poetry run python scripts/test_extraction_e2e.py"""
+
+
 async def test():
     # 약 500자 테스트 텍스트 (claim, opinion, excluded 혼합)
-    original_text = """대한민국의 수도는 서울이며, 인구는 약 970만 명입니다. 서울은 정말 살기 좋은 도시입니다. 2023년 한국의 GDP는 약 1조 7천억 달러로 세계 13위를 기록했습니다. 우리나라 경제는 앞으로 더욱 성장할 것입니다. 안녕하세요? 삼성전자는 1969년에 설립되었으며 현재 세계 최대의 메모리 반도체 제조사입니다. 애플이 삼성보다 더 혁신적이라고 생각합니다. 비트코인은 2009년 사토시 나카모토에 의해 만들어졌습니다. 암호화폐 투자는 신중하게 해야 합니다. 오늘 날씨 어때요? 한국어는 약 7천7백만 명이 사용하는 언어입니다. 한국 음식은 세계에서 가장 맛있습니다."""
-    
+    original_text = (
+        "대한민국의 수도는 서울이며, 인구는 약 970만 명입니다. "
+        "서울은 정말 살기 좋은 도시입니다. "
+        "2023년 한국의 GDP는 약 1조 7천억 달러로 세계 13위를 기록했습니다. "
+        "우리나라 경제는 앞으로 더욱 성장할 것입니다. "
+        "안녕하세요? "
+        "삼성전자는 1969년에 설립되었으며 현재 세계 최대의 메모리 반도체 제조사입니다. "
+        "애플이 삼성보다 더 혁신적이라고 생각합니다. "
+        "비트코인은 2009년 사토시 나카모토에 의해 만들어졌습니다. "
+        "암호화폐 투자는 신중하게 해야 합니다. "
+        "오늘 날씨 어때요? "
+        "한국어는 약 7천7백만 명이 사용하는 언어입니다. "
+        "한국 음식은 세계에서 가장 맛있습니다."
+    )
+
     state = {
         "original_text": original_text,
         "title": "",
         "sentences": [],
         "whitelist": [],
-        "blacklist": []
+        "blacklist": [],
     }
-    
+
     result = await extraction_node(state)
-    
+
     print("Title:", result["title"])
     print("Original:", original_text)
     print()
-    
+
     all_valid = True
     for s in result["sentences"]:
         type_str = s["type"]
         text_str = s["text"]
         start = s["startIndex"]
         end = s["endIndex"]
-        
+
         # -1 인덱스 처리: LLM이 원본에서 문장을 찾지 못한 경우
         if start == -1:
             print(f"[{type_str}] {text_str}")
-            print(f"  ⚠️ Sentence not found in original text (index: -1)")
+            print("  ⚠️ Sentence not found in original text (index: -1)")
             if "reason" in s:
                 print(f"  reason: {s['reason']}")
             print()
             all_valid = False
             continue
-        
+
         # 인덱스 검증: original_text[start:end]가 text와 일치하는지
         extracted = original_text[start:end]
         is_valid = extracted == text_str
         status = "✅" if is_valid else "❌"
-        
+
         if not is_valid:
             all_valid = False
-        
+
         print(f"[{type_str}] {text_str}")
         print(f"  indices: [{start}:{end}]")
         print(f"  extracted: '{extracted}' {status}")
         if "reason" in s:
             print(f"  reason: {s['reason']}")
         print()
-    
+
     if all_valid:
         print("✅ All indices are correct!")
     else:

--- a/scripts/test_extraction_e2e.py
+++ b/scripts/test_extraction_e2e.py
@@ -1,0 +1,57 @@
+"""E2E test for extraction_node with real Gemini API"""
+from dotenv import load_dotenv
+load_dotenv()
+
+import asyncio
+from graph.nodes.extraction import extraction_node
+
+
+"""사용법(터미널): PYTHONPATH=src poetry run python scripts/test_extraction_e2e.py"""
+async def test():
+    # 약 500자 테스트 텍스트 (claim, opinion, excluded 혼합)
+    original_text = """대한민국의 수도는 서울이며, 인구는 약 970만 명입니다. 서울은 정말 살기 좋은 도시입니다. 2023년 한국의 GDP는 약 1조 7천억 달러로 세계 13위를 기록했습니다. 우리나라 경제는 앞으로 더욱 성장할 것입니다. 안녕하세요? 삼성전자는 1969년에 설립되었으며 현재 세계 최대의 메모리 반도체 제조사입니다. 애플이 삼성보다 더 혁신적이라고 생각합니다. 비트코인은 2009년 사토시 나카모토에 의해 만들어졌습니다. 암호화폐 투자는 신중하게 해야 합니다. 오늘 날씨 어때요? 한국어는 약 7천7백만 명이 사용하는 언어입니다. 한국 음식은 세계에서 가장 맛있습니다."""
+    
+    state = {
+        "original_text": original_text,
+        "title": "",
+        "sentences": [],
+        "whitelist": [],
+        "blacklist": []
+    }
+    
+    result = await extraction_node(state)
+    
+    print("Title:", result["title"])
+    print("Original:", original_text)
+    print()
+    
+    all_valid = True
+    for s in result["sentences"]:
+        type_str = s["type"]
+        text_str = s["text"]
+        start = s["startIndex"]
+        end = s["endIndex"]
+        
+        # 인덱스 검증: original_text[start:end]가 text와 일치하는지
+        extracted = original_text[start:end]
+        is_valid = extracted == text_str
+        status = "✅" if is_valid else "❌"
+        
+        if not is_valid:
+            all_valid = False
+        
+        print(f"[{type_str}] {text_str}")
+        print(f"  indices: [{start}:{end}]")
+        print(f"  extracted: '{extracted}' {status}")
+        if "reason" in s:
+            print(f"  reason: {s['reason']}")
+        print()
+    
+    if all_valid:
+        print("✅ All indices are correct!")
+    else:
+        print("❌ Some indices are incorrect!")
+
+
+if __name__ == "__main__":
+    asyncio.run(test())

--- a/src/graph/nodes/extraction.py
+++ b/src/graph/nodes/extraction.py
@@ -1,34 +1,23 @@
+import os
 from graph.state import FactCheckState
+from services.llm import GeminiService
 
 
 async def extraction_node(state: FactCheckState) -> FactCheckState:
     """
-    Extraction Node: 텍스트에서 팩트체크가 필요한 문장을 추출 (Mock)
+    Extraction Node: 텍스트에서 팩트체크가 필요한 문장을 추출
+    GeminiService를 사용해 실제 LLM 호출
     """
     original_text = state.get("original_text", "")
-
-    # ... 여기서 실제 LLM 호출 (지금은 Mock) ...
-    # API 호출 대기 시간 시뮬레이션 (0초)
-
-    # 더미 데이터 생성
-    # PipelineSentence 구조에 맞춰 데이터 생성
-    extracted_sentences = [
-        {
-            "type": "claim",
-            "text": f"Extracted claim from: {original_text[:10]}...",
-            "startIndex": 0,
-            "endIndex": 10,
-        },
-        {
-            "type": "opinion",
-            "text": "This is an opinion statement.",
-            "startIndex": 11,
-            "endIndex": 20,
-            "reason": "Contains subjective language."
-        }
-    ]
-
+    
+    api_key = os.getenv("GEMINI_API_KEY")
+    if not api_key:
+        raise ValueError("GEMINI_API_KEY environment variable is required")
+    
+    service = GeminiService(api_key=api_key)
+    result = await service.extract_sentences(original_text)
+    
     return {
-        "title": f"Topic: {original_text[:10]}...",
-        "sentences": extracted_sentences
+        "title": result["title"],
+        "sentences": result["sentences"]
     }

--- a/src/graph/nodes/extraction.py
+++ b/src/graph/nodes/extraction.py
@@ -1,4 +1,5 @@
 import os
+
 from graph.state import FactCheckState
 from services.llm import GeminiService
 
@@ -9,15 +10,12 @@ async def extraction_node(state: FactCheckState) -> FactCheckState:
     GeminiService를 사용해 실제 LLM 호출
     """
     original_text = state.get("original_text", "")
-    
+
     api_key = os.getenv("GEMINI_API_KEY")
     if not api_key:
         raise ValueError("GEMINI_API_KEY environment variable is required")
-    
+
     service = GeminiService(api_key=api_key)
     result = await service.extract_sentences(original_text)
-    
-    return {
-        "title": result["title"],
-        "sentences": result["sentences"]
-    }
+
+    return {"title": result["title"], "sentences": result["sentences"]}

--- a/src/graph/nodes/search.py
+++ b/src/graph/nodes/search.py
@@ -6,13 +6,13 @@ async def search_node(sentence: PipelineSentence) -> PipelineSentence:
     [MOCK]
     검색(Search)을 수행하는 노드입니다.
     """
-    
+
     # 1. retry_count 증가 (재검색인 경우)
     # workflow.py에서 초기화된 retry_count를 확인
     if "retry_count" in sentence:
         # 이 노드가 호출되었다는 것은, 처음이거나 재시도 중이라는 뜻.
         # 재시도 횟수를 여기서 증가시키면 다음 Verification 단계에서 확인 가능.
-        # 단, 첫 진입(Extraction 후)에는 0이어야 하는데, 
+        # 단, 첫 진입(Extraction 후)에는 0이어야 하는데,
         # Loop를 돌아서 다시 Search로 오면 증가시켜야 함.
         # 하지만 Graph 구조상 Search 노드는 매번 실행됨.
         # 따라서 "Search 실행 횟수"를 세는 것이 됨.
@@ -23,8 +23,8 @@ async def search_node(sentence: PipelineSentence) -> PipelineSentence:
         # "이게 재시도인가?"를 알아야 함.
         # 판별법: sources가 이미 채워져 있으면 재시도임. (처음엔 비어있음)
         if "sources" in sentence and sentence["sources"]:
-             sentence["retry_count"] += 1
-             
+            sentence["retry_count"] += 1
+
     # 2. 검색 수행 (Mock)
     # ... 실제 검색 API 호출 (비동기) ...
     # 재검색 시 다른 검색어를 사용하거나 결과를 다르게 할 수 있음
@@ -32,9 +32,9 @@ async def search_node(sentence: PipelineSentence) -> PipelineSentence:
         {
             "title": "Trusted Source A",
             "url": "https://example.com/a",
-            "snippet": f"This supports the claim X... (Retry: {sentence.get('retry_count', 0)})"
+            "snippet": f"This supports the claim X... (Retry: {sentence.get('retry_count', 0)})",
         }
     ]
-    
+
     # 순수 검색 노드이므로 검증 로직 호출 제거
     return sentence

--- a/src/graph/nodes/verification.py
+++ b/src/graph/nodes/verification.py
@@ -6,18 +6,18 @@ async def verification_node(sentence: PipelineSentence) -> PipelineSentence:
     [Logic]
     단일 문장(PipelineSentence)과 소스(Sources)를 바탕으로 진실 여부를 판정합니다.
     """
-    
+
     # ... 실제 검증 API 호출 ...
-    
+
     # PipelineSentence 구조에 맞춰 결과 업데이트
     # 재검색 루프 테스트를 위해 특정 조건에서 FALSE 반환하도록 Mocking 가능
     # 여기서는 retry_count가 0이면 FALSE, 1이상이면 TRUE로 하여 루프 동작 확인
-    
+
     if sentence.get("retry_count", 0) == 0:
-         sentence["verdict"] = "FALSE"
-         sentence["suggestion"] = "Need more evidence."
+        sentence["verdict"] = "FALSE"
+        sentence["suggestion"] = "Need more evidence."
     else:
-         sentence["verdict"] = "TRUE"
-         sentence["suggestion"] = None
-    
+        sentence["verdict"] = "TRUE"
+        sentence["suggestion"] = None
+
     return sentence

--- a/src/graph/state.py
+++ b/src/graph/state.py
@@ -4,15 +4,18 @@ from typing import Annotated, Literal, TypedDict
 
 class Source(TypedDict):
     """검색 결과 출처"""
+
     title: str
     url: str
     snippet: str
+
 
 class PipelineSentence(TypedDict, total=False):
     """
     파이프라인 내부에서 점진적으로 채워지는 문장 구조.
     total=False로 모든 필드가 선택적 (노드별로 점진적 추가).
     """
+
     # ===== 공통 (Extraction에서 채움) =====
     type: Literal["claim", "opinion", "excluded"]
     text: str

--- a/src/graph/workflow.py
+++ b/src/graph/workflow.py
@@ -16,14 +16,14 @@ def continue_to_processing(state: FactCheckState):
     단, 'type'이 'claim'인 문장만 처리 대상으로 선정합니다.
     """
     start_nodes = []
-    
+
     for s in state["sentences"]:
         if s.get("type") == "claim":
             # retry_count 초기화
             if "retry_count" not in s:
                 s["retry_count"] = 0
             start_nodes.append(Send("processing_node", s))
-            
+
     return start_nodes
 
 
@@ -33,7 +33,7 @@ def check_verification_result(sentence: PipelineSentence):
     검증 결과가 FALSE이고 재시도 횟수가 남았으면 Search로 루프(Loop)
     """
     MAX_RETRIES = 1
-    
+
     if sentence.get("verdict") == "FALSE":
         current_retries = sentence.get("retry_count", 0)
         if current_retries < MAX_RETRIES:
@@ -41,7 +41,7 @@ def check_verification_result(sentence: PipelineSentence):
             # search_node에서 수행하거나 별도 노드가 필요함.
             # 여기서는 편의상 "search_node"가 retry_count를 보고 증가시킨다고 가정.
             return "search"
-            
+
     return END
 
 
@@ -54,15 +54,12 @@ def create_processing_subgraph():
 
     workflow.add_edge(START, "search")
     workflow.add_edge("search", "verification")
-    
+
     workflow.add_conditional_edges(
-        "verification",
-        check_verification_result,
-        {"search": "search", END: END}
+        "verification", check_verification_result, {"search": "search", END: END}
     )
 
     return workflow.compile()
-
 
     return workflow.compile()
 
@@ -83,18 +80,14 @@ def create_graph():
 
     # 1. 노드 추가
     graph_builder.add_node("extraction", extraction_node)
-    
+
     # SubGraph를 감싼 래퍼 노드 추가
     graph_builder.add_node("processing_node", processing_node)
 
     # 2. 엣지 연결
     graph_builder.add_edge(START, "extraction")
-    
+
     # Extraction -> (Map) -> Processing Wrapper
-    graph_builder.add_conditional_edges(
-        "extraction",
-        continue_to_processing,
-        ["processing_node"]
-    )
-    
+    graph_builder.add_conditional_edges("extraction", continue_to_processing, ["processing_node"])
+
     return graph_builder.compile()

--- a/src/services/llm.py
+++ b/src/services/llm.py
@@ -72,6 +72,7 @@ class GeminiService:
             api_key: Gemini API 키
         """
         self.client = genai.Client(api_key=api_key)
+        # TODO: 모델명 관리(환경 변수 or 설정 파일)
         self.model = "gemini-2.5-flash-lite"
     
     async def extract_sentences(self, text: str) -> dict:

--- a/src/services/llm.py
+++ b/src/services/llm.py
@@ -22,7 +22,7 @@ class ExtractionResult(BaseModel):
     sentences: list[ExtractedSentence]
 
 
-EXTRACTION_PROMPT = """\
+EXTRACTION_PROMPT = """
 You are a fact-checking assistant that extracts and classifies sentences from text.
 
 ## Your Task
@@ -61,9 +61,11 @@ Examples: "Hello!", "What do you think?", "It is good." (unclear referent)
 - text: MUST be the EXACT substring from the original text
   (preserve all characters including punctuation)
 - reason: Required for opinion and excluded types (explain WHY in Korean, 1 sentence)
+- sentences: MUST be returned in the same order they appear in the original text
 
 ## Text to Analyze
-{text}"""
+{text}
+"""
 
 
 class GeminiService:

--- a/src/services/llm.py
+++ b/src/services/llm.py
@@ -1,0 +1,50 @@
+"""Gemini API 서비스 래퍼"""
+from google import genai
+import os
+from typing import Any
+
+
+class GeminiService:
+    """Gemini API 래퍼 클래스"""
+    
+    def __init__(self, api_key: str):
+        """
+        Args:
+            api_key: Gemini API 키
+        """
+        self.client = genai.Client(api_key=api_key)
+        self.model = "gemini-2.0-flash-001"
+    
+    async def extract_sentences(self, text: str) -> list[dict]:
+        """
+        텍스트에서 문장 추출 및 분류
+        
+        Args:
+            text: 원본 텍스트
+            
+        Returns:
+            문장 리스트 (type, text, startIndex, endIndex, reason?)
+        """
+        # TODO: Gemini API 호출
+        # - JSON mode 사용
+        # - 타임아웃 30초
+        # - 재시도 최대 3회
+        pass
+    
+    async def verify_claim(
+        self, 
+        claim: str, 
+        sources: list[dict]
+    ) -> dict:
+        """
+        Claim 검증
+        
+        Args:
+            claim: 검증할 주장
+            sources: 검색된 소스 리스트
+            
+        Returns:
+            검증 결과 (verdict: TRUE/FALSE, suggestion?)
+        """
+        # TODO: Gemini API 호출
+        pass

--- a/src/services/llm.py
+++ b/src/services/llm.py
@@ -1,27 +1,29 @@
 """Gemini API 서비스 래퍼"""
+
+from typing import Literal
+
 from google import genai
 from google.genai import types
 from pydantic import BaseModel, Field
-from typing import Literal
 
 
 class ExtractedSentence(BaseModel):
     """추출된 문장 스키마 (LLM 응답용 - 인덱스 없음)"""
+
     type: Literal["claim", "opinion", "excluded"]
     text: str
-    reason: str | None = Field(
-        default=None, 
-        description="opinion 또는 excluded인 경우 분류 이유"
-    )
+    reason: str | None = Field(default=None, description="opinion 또는 excluded인 경우 분류 이유")
 
 
 class ExtractionResult(BaseModel):
     """문장 추출 결과"""
+
     title: str = Field(description="텍스트의 핵심 주제를 요약한 제목 (15자 이내)")
     sentences: list[ExtractedSentence]
 
 
-EXTRACTION_PROMPT = """You are a fact-checking assistant that extracts and classifies sentences from text.
+EXTRACTION_PROMPT = """\
+You are a fact-checking assistant that extracts and classifies sentences from text.
 
 ## Your Task
 1. Extract ALL sentences from the given text
@@ -56,7 +58,8 @@ Sentences that cannot or should not be fact-checked:
 Examples: "Hello!", "What do you think?", "It is good." (unclear referent)
 
 ## Output Requirements
-- text: MUST be the EXACT substring from the original text (preserve all characters including punctuation)
+- text: MUST be the EXACT substring from the original text
+  (preserve all characters including punctuation)
 - reason: Required for opinion and excluded types (explain WHY in Korean, 1 sentence)
 
 ## Text to Analyze
@@ -65,7 +68,7 @@ Examples: "Hello!", "What do you think?", "It is good." (unclear referent)
 
 class GeminiService:
     """Gemini API 래퍼 클래스"""
-    
+
     def __init__(self, api_key: str):
         """
         Args:
@@ -74,20 +77,20 @@ class GeminiService:
         self.client = genai.Client(api_key=api_key)
         # TODO: 모델명 관리(환경 변수 or 설정 파일)
         self.model = "gemini-2.5-flash-lite"
-    
+
     async def extract_sentences(self, text: str) -> dict:
         """
         텍스트에서 문장 추출 및 분류
-        
+
         Args:
             text: 원본 텍스트
-            
+
         Returns:
             {"title": str, "sentences": list[dict]}
             각 sentence는 type, text, startIndex, endIndex, reason?(opinion/excluded) 포함
         """
         prompt = EXTRACTION_PROMPT.format(text=text)
-        
+
         response = await self.client.aio.models.generate_content(
             model=self.model,
             contents=prompt,
@@ -97,16 +100,16 @@ class GeminiService:
                 temperature=0.1,  # 일관된 분류를 위해 낮은 temperature
             ),
         )
-        
+
         result = ExtractionResult.model_validate_json(response.text)
-        
+
         # 후처리: 원본 텍스트에서 인덱스 계산
         sentences_with_indices = []
         search_start = 0  # 순서대로 검색하여 중복 문장 처리
-        
+
         for s in result.sentences:
             sentence_dict = s.model_dump(exclude_none=True)
-            
+
             # 원본 텍스트에서 문장 위치 찾기
             idx = text.find(s.text, search_start)
             if idx != -1:
@@ -117,26 +120,19 @@ class GeminiService:
                 # 찾지 못한 경우 -1로 표시
                 sentence_dict["startIndex"] = -1
                 sentence_dict["endIndex"] = -1
-            
+
             sentences_with_indices.append(sentence_dict)
-        
-        return {
-            "title": result.title,
-            "sentences": sentences_with_indices
-        }
-    
-    async def verify_claim(
-        self, 
-        claim: str, 
-        sources: list[dict]
-    ) -> dict:
+
+        return {"title": result.title, "sentences": sentences_with_indices}
+
+    async def verify_claim(self, claim: str, sources: list[dict]) -> dict:
         """
         Claim 검증
-        
+
         Args:
             claim: 검증할 주장
             sources: 검색된 소스 리스트
-            
+
         Returns:
             검증 결과 (verdict: TRUE/FALSE, suggestion?)
         """

--- a/src/services/llm.py
+++ b/src/services/llm.py
@@ -1,7 +1,66 @@
 """Gemini API 서비스 래퍼"""
 from google import genai
-import os
-from typing import Any
+from google.genai import types
+from pydantic import BaseModel, Field
+from typing import Literal
+
+
+class ExtractedSentence(BaseModel):
+    """추출된 문장 스키마 (LLM 응답용 - 인덱스 없음)"""
+    type: Literal["claim", "opinion", "excluded"]
+    text: str
+    reason: str | None = Field(
+        default=None, 
+        description="opinion 또는 excluded인 경우 분류 이유"
+    )
+
+
+class ExtractionResult(BaseModel):
+    """문장 추출 결과"""
+    title: str = Field(description="텍스트의 핵심 주제를 요약한 제목 (15자 이내)")
+    sentences: list[ExtractedSentence]
+
+
+EXTRACTION_PROMPT = """You are a fact-checking assistant that extracts and classifies sentences from text.
+
+## Your Task
+1. Extract ALL sentences from the given text
+2. Classify each sentence into one of three categories
+3. Generate a concise title (max 15 characters) that summarizes the main topic
+
+## Classification Criteria
+
+### claim (Fact-checkable)
+Sentences containing objective, verifiable information:
+- Statistics, numbers, dates, measurements
+- Named entities (people, organizations, places)
+- Historical events or scientific facts
+- Statements that can be verified with external sources
+Examples: "The capital of Korea is Seoul.", "Bitcoin was launched in 2009."
+
+### opinion (Subjective)
+Sentences expressing personal views, judgments, or preferences:
+- Words like "should", "must", "need to" (normative statements)
+- Evaluative adjectives: "best", "worst", "beautiful", "terrible"
+- Predictions without factual basis
+- Personal feelings or beliefs
+Examples: "Seoul is a beautiful city.", "This policy will fail."
+
+### excluded (Not fact-checkable)
+Sentences that cannot or should not be fact-checked:
+- Greetings, farewells
+- Questions
+- Sentences with only pronouns (no clear referent)
+- Incomplete sentences or fragments
+- Commands or requests
+Examples: "Hello!", "What do you think?", "It is good." (unclear referent)
+
+## Output Requirements
+- text: MUST be the EXACT substring from the original text (preserve all characters including punctuation)
+- reason: Required for opinion and excluded types (explain WHY in Korean, 1 sentence)
+
+## Text to Analyze
+{text}"""
 
 
 class GeminiService:
@@ -13,9 +72,9 @@ class GeminiService:
             api_key: Gemini API 키
         """
         self.client = genai.Client(api_key=api_key)
-        self.model = "gemini-2.0-flash-001"
+        self.model = "gemini-2.5-flash-lite"
     
-    async def extract_sentences(self, text: str) -> list[dict]:
+    async def extract_sentences(self, text: str) -> dict:
         """
         텍스트에서 문장 추출 및 분류
         
@@ -23,13 +82,47 @@ class GeminiService:
             text: 원본 텍스트
             
         Returns:
-            문장 리스트 (type, text, startIndex, endIndex, reason?)
+            {"title": str, "sentences": list[dict]}
+            각 sentence는 type, text, startIndex, endIndex, reason?(opinion/excluded) 포함
         """
-        # TODO: Gemini API 호출
-        # - JSON mode 사용
-        # - 타임아웃 30초
-        # - 재시도 최대 3회
-        pass
+        prompt = EXTRACTION_PROMPT.format(text=text)
+        
+        response = await self.client.aio.models.generate_content(
+            model=self.model,
+            contents=prompt,
+            config=types.GenerateContentConfig(
+                response_mime_type="application/json",
+                response_schema=ExtractionResult,
+                temperature=0.1,  # 일관된 분류를 위해 낮은 temperature
+            ),
+        )
+        
+        result = ExtractionResult.model_validate_json(response.text)
+        
+        # 후처리: 원본 텍스트에서 인덱스 계산
+        sentences_with_indices = []
+        search_start = 0  # 순서대로 검색하여 중복 문장 처리
+        
+        for s in result.sentences:
+            sentence_dict = s.model_dump(exclude_none=True)
+            
+            # 원본 텍스트에서 문장 위치 찾기
+            idx = text.find(s.text, search_start)
+            if idx != -1:
+                sentence_dict["startIndex"] = idx
+                sentence_dict["endIndex"] = idx + len(s.text)
+                search_start = idx + len(s.text)  # 다음 검색 시작점
+            else:
+                # 찾지 못한 경우 -1로 표시
+                sentence_dict["startIndex"] = -1
+                sentence_dict["endIndex"] = -1
+            
+            sentences_with_indices.append(sentence_dict)
+        
+        return {
+            "title": result.title,
+            "sentences": sentences_with_indices
+        }
     
     async def verify_claim(
         self, 

--- a/src/services/llm_spec.py
+++ b/src/services/llm_spec.py
@@ -1,0 +1,56 @@
+"""GeminiService Mock 테스트"""
+import pytest
+from unittest.mock import AsyncMock
+from services import llm
+
+
+@pytest.mark.asyncio
+async def test_gemini_service_extract_sentences(mocker):
+    """문장 추출 API 호출 테스트 (Mock)"""
+    # Mock 준비
+    mock_response = [
+        {
+            "type": "claim",
+            "text": "테스트 문장입니다.",
+            "startIndex": 0,
+            "endIndex": 10
+        }
+    ]
+    
+    # GeminiService.extract_sentences Mock 처리
+    mocker.patch.object(
+        llm.GeminiService,
+        "extract_sentences",
+        new=AsyncMock(return_value=mock_response)
+    )
+    
+    # 실행
+    service = llm.GeminiService(api_key="test-key")
+    result = await service.extract_sentences("테스트 텍스트")
+    
+    # 검증
+    assert len(result) > 0
+    assert result[0]["type"] == "claim"
+
+
+@pytest.mark.asyncio
+async def test_gemini_service_verify_claim(mocker):
+    """Claim 검증 API 호출 테스트 (Mock)"""
+    mock_response = {
+        "verdict": "TRUE",
+        "suggestion": None
+    }
+    
+    mocker.patch.object(
+        llm.GeminiService,
+        "verify_claim",
+        new=AsyncMock(return_value=mock_response)
+    )
+    
+    service = llm.GeminiService(api_key="test-key")
+    mock_sources = [
+        {"title": "Example Source", "url": "https://example.com", "snippet": "관련 정보..."}
+    ]
+    result = await service.verify_claim("테스트 주장", mock_sources)
+    
+    assert result["verdict"] == "TRUE"

--- a/src/services/llm_spec.py
+++ b/src/services/llm_spec.py
@@ -1,21 +1,24 @@
 """GeminiService Mock 테스트"""
 import pytest
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 from services import llm
 
 
 @pytest.mark.asyncio
 async def test_gemini_service_extract_sentences(mocker):
-    """문장 추출 API 호출 테스트 (Mock)"""
-    # Mock 준비
-    mock_response = [
-        {
-            "type": "claim",
-            "text": "테스트 문장입니다.",
-            "startIndex": 0,
-            "endIndex": 10
-        }
-    ]
+    """문장 추출 API 호출 테스트 (Mock) - 반환 타입 일치 확인"""
+    # Mock 준비 - 실제 반환 형식과 일치
+    mock_response = {
+        "title": "테스트 제목",
+        "sentences": [
+            {
+                "type": "claim",
+                "text": "테스트 문장입니다.",
+                "startIndex": 0,
+                "endIndex": 10
+            }
+        ]
+    }
     
     # GeminiService.extract_sentences Mock 처리
     mocker.patch.object(
@@ -28,9 +31,10 @@ async def test_gemini_service_extract_sentences(mocker):
     service = llm.GeminiService(api_key="test-key")
     result = await service.extract_sentences("테스트 텍스트")
     
-    # 검증
-    assert len(result) > 0
-    assert result[0]["type"] == "claim"
+    # 검증 - 실제 반환 구조에 맞게 수정
+    assert result["title"] == "테스트 제목"
+    assert len(result["sentences"]) > 0
+    assert result["sentences"][0]["type"] == "claim"
 
 
 @pytest.mark.asyncio
@@ -54,3 +58,118 @@ async def test_gemini_service_verify_claim(mocker):
     result = await service.verify_claim("테스트 주장", mock_sources)
     
     assert result["verdict"] == "TRUE"
+
+
+@pytest.mark.asyncio
+async def test_extract_sentences_index_calculation(mocker):
+    """인덱스 계산 로직 테스트 - 원본 텍스트에서 문장 위치 정확도"""
+    # 원본 텍스트
+    original_text = "첫 번째 문장입니다. 두 번째 문장입니다."
+    
+    # LLM 응답 Mock (인덱스 없음 - 실제 LLM 응답처럼)
+    mock_llm_result = llm.ExtractionResult(
+        title="테스트",
+        sentences=[
+            llm.ExtractedSentence(type="claim", text="첫 번째 문장입니다."),
+            llm.ExtractedSentence(type="claim", text="두 번째 문장입니다."),
+        ]
+    )
+    
+    # Gemini API 응답 Mock
+    mock_api_response = MagicMock()
+    mock_api_response.text = mock_llm_result.model_dump_json()
+    
+    # Client Mock
+    mock_client = MagicMock()
+    mock_client.aio.models.generate_content = AsyncMock(return_value=mock_api_response)
+    mocker.patch.object(llm.genai, "Client", return_value=mock_client)
+    
+    # 실행
+    service = llm.GeminiService(api_key="test-key")
+    result = await service.extract_sentences(original_text)
+    
+    # 검증 - 인덱스가 정확히 계산되었는지
+    assert result["sentences"][0]["startIndex"] == 0
+    assert result["sentences"][0]["endIndex"] == 11  # "첫 번째 문장입니다." 길이
+    assert result["sentences"][1]["startIndex"] == 12  # 공백 포함
+    assert result["sentences"][1]["endIndex"] == 23  # "두 번째 문장입니다." 끝
+
+
+@pytest.mark.asyncio
+async def test_extract_sentences_duplicate_handling(mocker):
+    """중복 문장 처리 테스트 - 같은 문장이 2번 나올 때 각각 다른 인덱스"""
+    # 같은 문장이 두 번 나오는 텍스트
+    original_text = "안녕하세요. 반갑습니다. 안녕하세요."
+    
+    mock_llm_result = llm.ExtractionResult(
+        title="인사",
+        sentences=[
+            llm.ExtractedSentence(type="excluded", text="안녕하세요.", reason="인사말"),
+            llm.ExtractedSentence(type="excluded", text="반갑습니다.", reason="인사말"),
+            llm.ExtractedSentence(type="excluded", text="안녕하세요.", reason="인사말"),
+        ]
+    )
+    
+    mock_api_response = MagicMock()
+    mock_api_response.text = mock_llm_result.model_dump_json()
+    
+    mock_client = MagicMock()
+    mock_client.aio.models.generate_content = AsyncMock(return_value=mock_api_response)
+    mocker.patch.object(llm.genai, "Client", return_value=mock_client)
+    
+    # 실행
+    service = llm.GeminiService(api_key="test-key")
+    result = await service.extract_sentences(original_text)
+    
+    # 검증 - 첫 번째 "안녕하세요"와 두 번째 "안녕하세요"의 인덱스가 다름
+    assert result["sentences"][0]["startIndex"] == 0   # 첫 번째 "안녕하세요."
+    assert result["sentences"][0]["endIndex"] == 6
+    assert result["sentences"][2]["startIndex"] == 14  # 두 번째 "안녕하세요."
+    assert result["sentences"][2]["endIndex"] == 20
+
+
+@pytest.mark.asyncio  
+async def test_extract_sentences_not_found_in_text(mocker):
+    """문장을 원본에서 찾지 못할 때 -1 반환 테스트"""
+    original_text = "원본 텍스트입니다."
+    
+    # LLM이 원본에 없는 문장을 반환하는 경우 (할루시네이션)
+    mock_llm_result = llm.ExtractionResult(
+        title="테스트",
+        sentences=[
+            llm.ExtractedSentence(type="claim", text="존재하지 않는 문장"),
+        ]
+    )
+    
+    mock_api_response = MagicMock()
+    mock_api_response.text = mock_llm_result.model_dump_json()
+    
+    mock_client = MagicMock()
+    mock_client.aio.models.generate_content = AsyncMock(return_value=mock_api_response)
+    mocker.patch.object(llm.genai, "Client", return_value=mock_client)
+    
+    # 실행
+    service = llm.GeminiService(api_key="test-key")
+    result = await service.extract_sentences(original_text)
+    
+    # 검증 - 찾지 못한 경우 -1
+    assert result["sentences"][0]["startIndex"] == -1
+    assert result["sentences"][0]["endIndex"] == -1
+
+
+@pytest.mark.asyncio
+async def test_extract_sentences_api_error(mocker):
+    """API 호출 실패 시 예외 전파 테스트"""
+    mock_client = MagicMock()
+    mock_client.aio.models.generate_content = AsyncMock(
+        side_effect=Exception("API rate limit exceeded")
+    )
+    mocker.patch.object(llm.genai, "Client", return_value=mock_client)
+    
+    service = llm.GeminiService(api_key="test-key")
+    
+    # 예외가 전파되는지 확인
+    with pytest.raises(Exception) as exc_info:
+        await service.extract_sentences("테스트")
+    
+    assert "rate limit" in str(exc_info.value)

--- a/src/services/llm_spec.py
+++ b/src/services/llm_spec.py
@@ -1,6 +1,9 @@
 """GeminiService Mock 테스트"""
-import pytest
+
 from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
 from services import llm
 
 
@@ -11,26 +14,19 @@ async def test_gemini_service_extract_sentences(mocker):
     mock_response = {
         "title": "테스트 제목",
         "sentences": [
-            {
-                "type": "claim",
-                "text": "테스트 문장입니다.",
-                "startIndex": 0,
-                "endIndex": 10
-            }
-        ]
+            {"type": "claim", "text": "테스트 문장입니다.", "startIndex": 0, "endIndex": 10}
+        ],
     }
-    
+
     # GeminiService.extract_sentences Mock 처리
     mocker.patch.object(
-        llm.GeminiService,
-        "extract_sentences",
-        new=AsyncMock(return_value=mock_response)
+        llm.GeminiService, "extract_sentences", new=AsyncMock(return_value=mock_response)
     )
-    
+
     # 실행
     service = llm.GeminiService(api_key="test-key")
     result = await service.extract_sentences("테스트 텍스트")
-    
+
     # 검증 - 실제 반환 구조에 맞게 수정
     assert result["title"] == "테스트 제목"
     assert len(result["sentences"]) > 0
@@ -40,23 +36,18 @@ async def test_gemini_service_extract_sentences(mocker):
 @pytest.mark.asyncio
 async def test_gemini_service_verify_claim(mocker):
     """Claim 검증 API 호출 테스트 (Mock)"""
-    mock_response = {
-        "verdict": "TRUE",
-        "suggestion": None
-    }
-    
+    mock_response = {"verdict": "TRUE", "suggestion": None}
+
     mocker.patch.object(
-        llm.GeminiService,
-        "verify_claim",
-        new=AsyncMock(return_value=mock_response)
+        llm.GeminiService, "verify_claim", new=AsyncMock(return_value=mock_response)
     )
-    
+
     service = llm.GeminiService(api_key="test-key")
     mock_sources = [
         {"title": "Example Source", "url": "https://example.com", "snippet": "관련 정보..."}
     ]
     result = await service.verify_claim("테스트 주장", mock_sources)
-    
+
     assert result["verdict"] == "TRUE"
 
 
@@ -65,29 +56,29 @@ async def test_extract_sentences_index_calculation(mocker):
     """인덱스 계산 로직 테스트 - 원본 텍스트에서 문장 위치 정확도"""
     # 원본 텍스트
     original_text = "첫 번째 문장입니다. 두 번째 문장입니다."
-    
+
     # LLM 응답 Mock (인덱스 없음 - 실제 LLM 응답처럼)
     mock_llm_result = llm.ExtractionResult(
         title="테스트",
         sentences=[
             llm.ExtractedSentence(type="claim", text="첫 번째 문장입니다."),
             llm.ExtractedSentence(type="claim", text="두 번째 문장입니다."),
-        ]
+        ],
     )
-    
+
     # Gemini API 응답 Mock
     mock_api_response = MagicMock()
     mock_api_response.text = mock_llm_result.model_dump_json()
-    
+
     # Client Mock
     mock_client = MagicMock()
     mock_client.aio.models.generate_content = AsyncMock(return_value=mock_api_response)
     mocker.patch.object(llm.genai, "Client", return_value=mock_client)
-    
+
     # 실행
     service = llm.GeminiService(api_key="test-key")
     result = await service.extract_sentences(original_text)
-    
+
     # 검증 - 인덱스가 정확히 계산되었는지
     assert result["sentences"][0]["startIndex"] == 0
     assert result["sentences"][0]["endIndex"] == 11  # "첫 번째 문장입니다." 길이
@@ -100,58 +91,58 @@ async def test_extract_sentences_duplicate_handling(mocker):
     """중복 문장 처리 테스트 - 같은 문장이 2번 나올 때 각각 다른 인덱스"""
     # 같은 문장이 두 번 나오는 텍스트
     original_text = "안녕하세요. 반갑습니다. 안녕하세요."
-    
+
     mock_llm_result = llm.ExtractionResult(
         title="인사",
         sentences=[
             llm.ExtractedSentence(type="excluded", text="안녕하세요.", reason="인사말"),
             llm.ExtractedSentence(type="excluded", text="반갑습니다.", reason="인사말"),
             llm.ExtractedSentence(type="excluded", text="안녕하세요.", reason="인사말"),
-        ]
+        ],
     )
-    
+
     mock_api_response = MagicMock()
     mock_api_response.text = mock_llm_result.model_dump_json()
-    
+
     mock_client = MagicMock()
     mock_client.aio.models.generate_content = AsyncMock(return_value=mock_api_response)
     mocker.patch.object(llm.genai, "Client", return_value=mock_client)
-    
+
     # 실행
     service = llm.GeminiService(api_key="test-key")
     result = await service.extract_sentences(original_text)
-    
+
     # 검증 - 첫 번째 "안녕하세요"와 두 번째 "안녕하세요"의 인덱스가 다름
-    assert result["sentences"][0]["startIndex"] == 0   # 첫 번째 "안녕하세요."
+    assert result["sentences"][0]["startIndex"] == 0  # 첫 번째 "안녕하세요."
     assert result["sentences"][0]["endIndex"] == 6
     assert result["sentences"][2]["startIndex"] == 14  # 두 번째 "안녕하세요."
     assert result["sentences"][2]["endIndex"] == 20
 
 
-@pytest.mark.asyncio  
+@pytest.mark.asyncio
 async def test_extract_sentences_not_found_in_text(mocker):
     """문장을 원본에서 찾지 못할 때 -1 반환 테스트"""
     original_text = "원본 텍스트입니다."
-    
+
     # LLM이 원본에 없는 문장을 반환하는 경우 (할루시네이션)
     mock_llm_result = llm.ExtractionResult(
         title="테스트",
         sentences=[
             llm.ExtractedSentence(type="claim", text="존재하지 않는 문장"),
-        ]
+        ],
     )
-    
+
     mock_api_response = MagicMock()
     mock_api_response.text = mock_llm_result.model_dump_json()
-    
+
     mock_client = MagicMock()
     mock_client.aio.models.generate_content = AsyncMock(return_value=mock_api_response)
     mocker.patch.object(llm.genai, "Client", return_value=mock_client)
-    
+
     # 실행
     service = llm.GeminiService(api_key="test-key")
     result = await service.extract_sentences(original_text)
-    
+
     # 검증 - 찾지 못한 경우 -1
     assert result["sentences"][0]["startIndex"] == -1
     assert result["sentences"][0]["endIndex"] == -1
@@ -165,11 +156,11 @@ async def test_extract_sentences_api_error(mocker):
         side_effect=Exception("API rate limit exceeded")
     )
     mocker.patch.object(llm.genai, "Client", return_value=mock_client)
-    
+
     service = llm.GeminiService(api_key="test-key")
-    
+
     # 예외가 전파되는지 확인
     with pytest.raises(Exception) as exc_info:
         await service.extract_sentences("테스트")
-    
+
     assert "rate limit" in str(exc_info.value)

--- a/src/services/search.py
+++ b/src/services/search.py
@@ -1,0 +1,35 @@
+"""Tavily Search API 서비스 래퍼"""
+from tavily import TavilyClient
+
+
+class TavilyService:
+    """Tavily Search API 래퍼 클래스"""
+    
+    def __init__(self, api_key: str):
+        """
+        Args:
+            api_key: Tavily API 키
+        """
+        self.client = TavilyClient(api_key=api_key)
+    
+    async def search(
+        self,
+        query: str,
+        include_domains: list[str] = [],  # whitelist
+        exclude_domains: list[str] = [],  # blacklist
+        max_results: int = 5
+    ) -> list[dict]:
+        """
+        웹 검색 수행
+        
+        Args:
+            query: 검색 쿼리
+            include_domains: 우선 검색 도메인 (whitelist)
+            exclude_domains: 제외할 도메인 (blacklist)
+            max_results: 최대 결과 개수
+            
+        Returns:
+            검색 결과 리스트 (title, url, snippet)
+        """
+        # TODO: Tavily API 호출
+        pass

--- a/src/services/search.py
+++ b/src/services/search.py
@@ -1,34 +1,36 @@
 """Tavily Search API 서비스 래퍼"""
+
 from tavily import TavilyClient
+
 from graph.state import Source
 
 
 class TavilyService:
     """Tavily Search API 래퍼 클래스"""
-    
+
     def __init__(self, api_key: str):
         """
         Args:
             api_key: Tavily API 키
         """
         self.client = TavilyClient(api_key=api_key)
-    
+
     async def search(
         self,
         query: str,
         include_domains: list[str] | None = None,  # whitelist
         exclude_domains: list[str] | None = None,  # blacklist
-        max_results: int = 5
+        max_results: int = 5,
     ) -> list[Source]:
         """
         웹 검색 수행
-        
+
         Args:
             query: 검색 쿼리
             include_domains: 우선 검색 도메인 (whitelist)
             exclude_domains: 제외할 도메인 (blacklist)
             max_results: 최대 결과 개수
-            
+
         Returns:
             검색 결과 리스트 (title, url, snippet)
         """
@@ -36,4 +38,3 @@ class TavilyService:
         exclude_domains = exclude_domains or []
         # TODO: Tavily API 호출
         pass
-

--- a/src/services/search.py
+++ b/src/services/search.py
@@ -1,5 +1,6 @@
 """Tavily Search API 서비스 래퍼"""
 from tavily import TavilyClient
+from graph.state import Source
 
 
 class TavilyService:
@@ -15,10 +16,10 @@ class TavilyService:
     async def search(
         self,
         query: str,
-        include_domains: list[str] = [],  # whitelist
-        exclude_domains: list[str] = [],  # blacklist
+        include_domains: list[str] | None = None,  # whitelist
+        exclude_domains: list[str] | None = None,  # blacklist
         max_results: int = 5
-    ) -> list[dict]:
+    ) -> list[Source]:
         """
         웹 검색 수행
         
@@ -31,5 +32,8 @@ class TavilyService:
         Returns:
             검색 결과 리스트 (title, url, snippet)
         """
+        include_domains = include_domains or []
+        exclude_domains = exclude_domains or []
         # TODO: Tavily API 호출
         pass
+

--- a/src/services/search_spec.py
+++ b/src/services/search_spec.py
@@ -1,6 +1,9 @@
 """TavilyService Mock 테스트"""
-import pytest
+
 from unittest.mock import AsyncMock
+
+import pytest
+
 from services import search
 
 
@@ -8,22 +11,14 @@ from services import search
 async def test_tavily_service_search(mocker):
     """검색 API 호출 테스트 (Mock)"""
     mock_response = [
-        {
-            "title": "Example Title",
-            "url": "https://example.com",
-            "snippet": "Example snippet..."
-        }
+        {"title": "Example Title", "url": "https://example.com", "snippet": "Example snippet..."}
     ]
-    
-    mocker.patch.object(
-        search.TavilyService,
-        "search",
-        new=AsyncMock(return_value=mock_response)
-    )
-    
+
+    mocker.patch.object(search.TavilyService, "search", new=AsyncMock(return_value=mock_response))
+
     service = search.TavilyService(api_key="test-key")
     result = await service.search("테스트 쿼리")
-    
+
     assert len(result) > 0
     assert result[0]["url"] == "https://example.com"
 
@@ -34,19 +29,13 @@ async def test_tavily_service_with_domains(mocker):
     mock_response = [
         {"title": "Filtered Result", "url": "https://trusted.com", "snippet": "신뢰 도메인 결과"}
     ]
-    
-    mocker.patch.object(
-        search.TavilyService,
-        "search",
-        new=AsyncMock(return_value=mock_response)
-    )
-    
+
+    mocker.patch.object(search.TavilyService, "search", new=AsyncMock(return_value=mock_response))
+
     service = search.TavilyService(api_key="test-key")
     result = await service.search(
-        "테스트",
-        include_domains=["trusted.com"],
-        exclude_domains=["spam.com"]
+        "테스트", include_domains=["trusted.com"], exclude_domains=["spam.com"]
     )
-    
+
     assert isinstance(result, list)
     assert len(result) > 0

--- a/src/services/search_spec.py
+++ b/src/services/search_spec.py
@@ -1,0 +1,52 @@
+"""TavilyService Mock 테스트"""
+import pytest
+from unittest.mock import AsyncMock
+from services import search
+
+
+@pytest.mark.asyncio
+async def test_tavily_service_search(mocker):
+    """검색 API 호출 테스트 (Mock)"""
+    mock_response = [
+        {
+            "title": "Example Title",
+            "url": "https://example.com",
+            "snippet": "Example snippet..."
+        }
+    ]
+    
+    mocker.patch.object(
+        search.TavilyService,
+        "search",
+        new=AsyncMock(return_value=mock_response)
+    )
+    
+    service = search.TavilyService(api_key="test-key")
+    result = await service.search("테스트 쿼리")
+    
+    assert len(result) > 0
+    assert result[0]["url"] == "https://example.com"
+
+
+@pytest.mark.asyncio
+async def test_tavily_service_with_domains(mocker):
+    """도메인 필터링 테스트 (Mock)"""
+    mock_response = [
+        {"title": "Filtered Result", "url": "https://trusted.com", "snippet": "신뢰 도메인 결과"}
+    ]
+    
+    mocker.patch.object(
+        search.TavilyService,
+        "search",
+        new=AsyncMock(return_value=mock_response)
+    )
+    
+    service = search.TavilyService(api_key="test-key")
+    result = await service.search(
+        "테스트",
+        include_domains=["trusted.com"],
+        exclude_domains=["spam.com"]
+    )
+    
+    assert isinstance(result, list)
+    assert len(result) > 0

--- a/tests/graph/nodes_spec.py
+++ b/tests/graph/nodes_spec.py
@@ -1,7 +1,8 @@
 """Mock 노드 단위 테스트"""
 
-import pytest
 from unittest.mock import AsyncMock, patch
+
+import pytest
 
 from graph.nodes import extraction, search, verification
 from graph.state import FactCheckState, PipelineSentence
@@ -21,20 +22,13 @@ async def test_extraction_node():
     mock_result = {
         "title": "테스트 제목",
         "sentences": [
-            {
-                "type": "claim",
-                "text": "테스트 문장입니다.",
-                "startIndex": 0,
-                "endIndex": 10
-            }
-        ]
+            {"type": "claim", "text": "테스트 문장입니다.", "startIndex": 0, "endIndex": 10}
+        ],
     }
 
     with patch.dict("os.environ", {"GEMINI_API_KEY": "test-key"}):
         with patch.object(
-            extraction.GeminiService,
-            "extract_sentences",
-            new=AsyncMock(return_value=mock_result)
+            extraction.GeminiService, "extract_sentences", new=AsyncMock(return_value=mock_result)
         ):
             new_state = await extraction.extraction_node(initial_state)
 
@@ -50,11 +44,11 @@ async def test_search_node():
     """Search 노드가 검색을 수행하고 sources를 추가하는지 테스트"""
     # 초기 상태 (첫 진입)
     sentence: PipelineSentence = {
-        "type": "claim", 
+        "type": "claim",
         "text": "테스트 주장",
-        "startIndex": 0, 
+        "startIndex": 0,
         "endIndex": 5,
-        "retry_count": 0
+        "retry_count": 0,
     }
 
     result = await search.search_node(sentence)
@@ -69,18 +63,18 @@ async def test_search_node_retry():
     """Search 노드가 재진입 시 retry_count를 증가시키는지 테스트"""
     # 재진입 상태 (이미 sources가 있음)
     sentence: PipelineSentence = {
-        "type": "claim", 
+        "type": "claim",
         "text": "테스트 주장",
-        "startIndex": 0, 
+        "startIndex": 0,
         "endIndex": 5,
         "retry_count": 0,
-        "sources": [{"title": "Old", "url": "url", "snippet": "old"}]
+        "sources": [{"title": "Old", "url": "url", "snippet": "old"}],
     }
 
     result = await search.search_node(sentence)
 
     assert result["retry_count"] == 1  # 증가했어야 함
-    assert "sources" in result # 검색 다시 수행됨
+    assert "sources" in result  # 검색 다시 수행됨
 
 
 @pytest.mark.asyncio
@@ -92,13 +86,13 @@ async def test_verification_node():
         "startIndex": 0,
         "endIndex": 5,
         "sources": [{"title": "T", "url": "U", "snippet": "S"}],
-        "retry_count": 0
+        "retry_count": 0,
     }
 
     # retry_count가 0이면 Mock 로직상 FALSE
     result_false = await verification.verification_node(sentence)
     assert result_false["verdict"] == "FALSE"
-    
+
     # retry_count가 1이면 Mock 로직상 TRUE
     sentence["retry_count"] = 1
     result_true = await verification.verification_node(sentence)

--- a/tests/graph/nodes_spec.py
+++ b/tests/graph/nodes_spec.py
@@ -1,6 +1,7 @@
 """Mock 노드 단위 테스트"""
 
 import pytest
+from unittest.mock import AsyncMock, patch
 
 from graph.nodes import extraction, search, verification
 from graph.state import FactCheckState, PipelineSentence
@@ -17,7 +18,25 @@ async def test_extraction_node():
         "blacklist": [],
     }
 
-    new_state = await extraction.extraction_node(initial_state)
+    mock_result = {
+        "title": "테스트 제목",
+        "sentences": [
+            {
+                "type": "claim",
+                "text": "테스트 문장입니다.",
+                "startIndex": 0,
+                "endIndex": 10
+            }
+        ]
+    }
+
+    with patch.dict("os.environ", {"GEMINI_API_KEY": "test-key"}):
+        with patch.object(
+            extraction.GeminiService,
+            "extract_sentences",
+            new=AsyncMock(return_value=mock_result)
+        ):
+            new_state = await extraction.extraction_node(initial_state)
 
     assert len(new_state["sentences"]) > 0
     first_sent = new_state["sentences"][0]

--- a/tests/graph/workflow_spec.py
+++ b/tests/graph/workflow_spec.py
@@ -2,6 +2,9 @@
 
 import pytest
 
+from unittest.mock import AsyncMock, patch
+
+from graph.nodes import extraction
 from graph.state import FactCheckState
 from graph.workflow import create_graph
 
@@ -20,7 +23,33 @@ async def test_factcheck_workflow():
     }
 
     # ainvoke (Async Invoke) 사용
-    final_state = await workflow.ainvoke(initial_state)
+    
+    mock_extraction_result = {
+        "title": "Topic: AI Impact",
+        "sentences": [
+            {
+                "type": "claim",
+                "text": "AI is changing the world.",
+                "startIndex": 0,
+                "endIndex": 25,
+            },
+            {
+                "type": "opinion",
+                "text": "It is good.",
+                "startIndex": 26,
+                "endIndex": 37,
+                "reason": "Subjective judgment"
+            }
+        ]
+    }
+
+    with patch.dict("os.environ", {"GEMINI_API_KEY": "test-key"}):
+        with patch.object(
+            extraction.GeminiService, 
+            "extract_sentences", 
+            new=AsyncMock(return_value=mock_extraction_result)
+        ):
+            final_state = await workflow.ainvoke(initial_state)
 
     # 1. Title 생성 확인
     assert final_state["title"].startswith("Topic:")

--- a/tests/graph/workflow_spec.py
+++ b/tests/graph/workflow_spec.py
@@ -1,8 +1,8 @@
 """LangGraph 워크플로우 통합 테스트 (Mock)"""
 
-import pytest
-
 from unittest.mock import AsyncMock, patch
+
+import pytest
 
 from graph.nodes import extraction
 from graph.state import FactCheckState
@@ -23,7 +23,7 @@ async def test_factcheck_workflow():
     }
 
     # ainvoke (Async Invoke) 사용
-    
+
     mock_extraction_result = {
         "title": "Topic: AI Impact",
         "sentences": [
@@ -38,16 +38,16 @@ async def test_factcheck_workflow():
                 "text": "It is good.",
                 "startIndex": 26,
                 "endIndex": 37,
-                "reason": "Subjective judgment"
-            }
-        ]
+                "reason": "Subjective judgment",
+            },
+        ],
     }
 
     with patch.dict("os.environ", {"GEMINI_API_KEY": "test-key"}):
         with patch.object(
-            extraction.GeminiService, 
-            "extract_sentences", 
-            new=AsyncMock(return_value=mock_extraction_result)
+            extraction.GeminiService,
+            "extract_sentences",
+            new=AsyncMock(return_value=mock_extraction_result),
         ):
             final_state = await workflow.ainvoke(initial_state)
 
@@ -58,13 +58,12 @@ async def test_factcheck_workflow():
     sentences = final_state["sentences"]
     assert len(sentences) > 0
 
-    
     # 3. 문장 처리 결과 확인 (SubGraph & Loop)
     sentences = final_state["sentences"]
     # Reducer(add) 특성상 처리 전 문장과 처리 후 문장이 공존할 수 있음.
     # 따라서 "verdict" 키가 존재하는(=처리 완료된) Claim만 필터링해야 함.
     processed_claims = [s for s in sentences if s.get("type") == "claim" and "verdict" in s]
-    
+
     # 처리된 Claim이 하나 이상 존재해야 함
     assert len(processed_claims) > 0
 
@@ -74,16 +73,16 @@ async def test_factcheck_workflow():
         # 1. 첫 Search 진입 (retry_count=0) -> Verification (FALSE 반환) -> Loop
         # 2. 두번째 Search 진입 (retry_count=0 -> 1 증가) -> Verification (TRUE 반환) -> END
         # 따라서 최종 결과는 retry_count가 1이고 verdict가 TRUE여야 함.
-        
+
         assert "verdict" in claim
         if claim["verdict"] == "TRUE":
-             # 로직상 재시도 후 성공했으면 retry_count는 1이어야 함
-             # (만약 한 번에 성공하는 로직이라면 0일 수도 있음, Mock 로직 확인 필요)
-             assert claim.get("retry_count", 0) >= 0
+            # 로직상 재시도 후 성공했으면 retry_count는 1이어야 함
+            # (만약 한 번에 성공하는 로직이라면 0일 수도 있음, Mock 로직 확인 필요)
+            assert claim.get("retry_count", 0) >= 0
         else:
-             # 실패로 끝났다면 MAX_RETRIES 도달
-             assert claim.get("retry_count", 0) >= 1
-             
+            # 실패로 끝났다면 MAX_RETRIES 도달
+            assert claim.get("retry_count", 0) >= 1
+
     # Opinions 확인
     opinions = [s for s in sentences if s.get("type") == "opinion"]
     for opinion in opinions:


### PR DESCRIPTION
## 🎫 관련 이슈 (Related Issue)
- Closes #5 
- Closes #6 
- Closes #7 

## 🛠️ 작업 내용 (Description)

**AS-IS**
- 팩트체크 파이프라인이 Mock 데이터로만 동작
- 외부 API (Gemini, Tavily) 연동 부재
- 문장 추출/분류가 하드코딩된 상태

**TO-BE**
- **외부 서비스 래퍼 구현**
    - `GeminiService` (`src/services/llm.py`): Gemini API를 통한 문장 추출 및 분류
    - `TavilyService` (`src/services/search.py`): Tavily Search API 스텁 구현
  
- **Extraction 노드 실제 연동**
    - Mock → 실제 GeminiService 호출로 교체
    - claim/opinion/excluded 3종 분류 적용
    - 인덱스 계산 후처리 로직 구현 (`text.find()` 기반)

- **테스트 코드 추가**
    - `llm_spec.py`: GeminiService mock 테스트 6개
    - `search_spec.py`: TavilyService mock 테스트 2개
    - `nodes_spec.py`: extraction_node mock 테스트 갱신
    - `scripts/test_extraction_e2e.py`: E2E 테스트 스크립트

## 📝 주요 변경 파일

| 파일 | 변경 내용 |
|------|----------|
| `src/services/llm.py` | Pydantic 스키마, 프롬프트, `extract_sentences` 구현 |
| `src/services/search.py` | TavilyService 스텁 + mutable default 수정 |
| `src/graph/nodes/extraction.py` | Mock → 실제 GeminiService 호출 |
| `tests/graph/nodes_spec.py` | GeminiService mock 추가 |
| `README.md` | 설치 및 테스트 가이드 추가 |

##  📸 스크린샷 (Screenshots) 
<details>
<summary> e2e 테스트 - 펼쳐서 보기</summary>

| 구분 | 스크린샷 |
| :---: | :---: |
| e2e 테스트 | <img width="600" height="800" alt="스크린샷 2026-01-07 오후 2 21 05" src="https://github.com/user-attachments/assets/f929d3ee-83bf-4ea4-83e2-f08e6a018660" /> |

</details>

## ✅ 체크리스트 (Self Checklist)

**기본 확인**
- [x] 내 코드를 스스로 리뷰했나요? (오타, 불필요한 주석 제거)
- [x] 로컬에서 빌드 및 테스트가 통과했나요? (`poetry run pytest` 통과)
- [x] (필요 시) 관련 문서나 API 명세서를 업데이트했나요?

**안정성 및 배포**
- [x] 환경변수(.env) 변경 사항이 있다면 공유했나요? (`GEMINI_API_KEY` 필요)
- [x] 민감한 정보(API Key 등)가 코드에 포함되지 않았나요?

## 🧪 테스트 방법 (How to Test)

1. **Mock 테스트 실행**
   ```bash
   poetry run pytest
   ```

2. **E2E 테스트 실행** (API 키 필요)
   ```bash
   PYTHONPATH=src poetry run python scripts/test_extraction_e2e.py
   ```

## 📝 특이사항

- **인덱스 계산을 LLM 대신 후처리로 변경** - LLM 인덱스 오류율이 높아 (최대 100%) `text.find()` 방식 채택
- **-1 인덱스 fallback** - 문장 미발견 시 `-1` 반환, 클라이언트 용이므로 실질적 사용 x 