### PR TITLE
feat: claim 검색 및 검증 노드 구현 (#9, #10)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,3 @@
+# pydantic-settings 기반 필수 환경변수
 GEMINI_API_KEY=""
 TAVILY_API_KEY=""

--- a/README.md
+++ b/README.md
@@ -65,5 +65,5 @@ PYTHONPATH=src poetry run python scripts/test_extraction_e2e.py
 ## 개발 서버 실행
 
 ```bash
-poetry run uvicorn src.main:app --reload
+PYTHONPATH=src poetry run uvicorn main:app --reload
 ```

--- a/poetry.lock
+++ b/poetry.lock
@@ -1211,6 +1211,30 @@ files = [
 typing-extensions = ">=4.14.1"
 
 [[package]]
+name = "pydantic-settings"
+version = "2.12.0"
+description = "Settings management using Pydantic"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "pydantic_settings-2.12.0-py3-none-any.whl", hash = "sha256:fddb9fd99a5b18da837b29710391e945b1e30c135477f484084ee513adb93809"},
+    {file = "pydantic_settings-2.12.0.tar.gz", hash = "sha256:005538ef951e3c2a68e1c08b292b5f2e71490def8589d4221b95dab00dafcfd0"},
+]
+
+[package.dependencies]
+pydantic = ">=2.7.0"
+python-dotenv = ">=0.21.0"
+typing-inspection = ">=0.4.0"
+
+[package.extras]
+aws-secrets-manager = ["boto3 (>=1.35.0)", "boto3-stubs[secretsmanager]"]
+azure-key-vault = ["azure-identity (>=1.16.0)", "azure-keyvault-secrets (>=4.8.0)"]
+gcp-secret-manager = ["google-cloud-secret-manager (>=2.23.1)"]
+toml = ["tomli (>=2.0.1)"]
+yaml = ["pyyaml (>=6.0.1)"]
+
+[[package]]
 name = "pygments"
 version = "2.19.2"
 description = "Pygments is a syntax highlighting package written in Python."
@@ -2360,4 +2384,4 @@ cffi = ["cffi (>=1.17,<2.0) ; platform_python_implementation != \"PyPy\" and pyt
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.13,<4.0"
-content-hash = "a9032dc6479592ea5104da72bef5836c2b6b32bae5b063ed9856f8d6efa1a3ea"
+content-hash = "081424497e0768bf51d3b8b7a16ae450787ec6011739855c65741f178c8ed8ed"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,8 @@ dependencies = [
     "langgraph (>=1.0.5,<2.0.0)",
     "google-genai (>=1.56.0,<2.0.0)",
     "tavily-python (>=0.7.17,<0.8.0)",
-    "pydantic (>=2.12.5,<3.0.0)"
+    "pydantic (>=2.12.5,<3.0.0)",
+    "pydantic-settings (>=2.9.1,<3.0.0)"
 ]
 
 [tool.commitizen]

--- a/scripts/test_search_e2e.py
+++ b/scripts/test_search_e2e.py
@@ -1,0 +1,79 @@
+"""E2E test for search_node with real Tavily API"""
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+import asyncio  # noqa: E402
+
+from graph.nodes.search import search_node  # noqa: E402
+from graph.state import PipelineSentence  # noqa: E402
+
+"""사용법(터미널): PYTHONPATH=src poetry run python scripts/test_search_e2e.py"""
+
+
+async def test():
+    # 테스트할 claim 문장들
+    test_sentences: list[PipelineSentence] = [
+        {
+            "type": "claim",
+            "text": "비트코인은 2009년 사토시 나카모토에 의해 만들어졌습니다.",
+            "startIndex": 0,
+            "endIndex": 30,
+            "retry_count": 0,
+            "whitelist": [],
+            "blacklist": [],
+        },
+        {
+            "type": "claim",
+            "text": "삼성전자는 1969년에 설립되었습니다.",
+            "startIndex": 31,
+            "endIndex": 50,
+            "retry_count": 0,
+            "whitelist": ["samsung.com"],  # whitelist 테스트
+            "blacklist": ["wikipedia.org"],  # blacklist 테스트
+        },
+        {
+            "type": "claim",
+            "text": "한국의 GDP는 세계 13위입니다.",
+            "startIndex": 51,
+            "endIndex": 70,
+            "retry_count": 0,
+            "whitelist": [],
+            "blacklist": [],
+        },
+    ]
+
+    print("=" * 60)
+    print("Search Node E2E Test (Real Tavily API)")
+    print("=" * 60)
+
+    for i, sentence in enumerate(test_sentences, 1):
+        print(f"\n[Test {i}] Query: {sentence['text']}")
+        if sentence.get("whitelist"):
+            print(f"  whitelist: {sentence['whitelist']}")
+        if sentence.get("blacklist"):
+            print(f"  blacklist: {sentence['blacklist']}")
+        print("-" * 40)
+
+        try:
+            result = await search_node(sentence)
+
+            sources = result.get("sources", [])
+            print(f"  ✅ Found {len(sources)} sources:")
+            for j, source in enumerate(sources, 1):
+                print(f"     {j}. {source['title']}")
+                print(f"        URL: {source['url']}")
+                print(f"        Snippet: {source['snippet'][:100]}...")
+                print()
+
+        except Exception as e:
+            print(f"  ❌ Error: {e}")
+
+    print("=" * 60)
+    print("Test completed!")
+    print("=" * 60)
+
+
+if __name__ == "__main__":
+    asyncio.run(test())

--- a/scripts/test_verification_e2e.py
+++ b/scripts/test_verification_e2e.py
@@ -1,0 +1,101 @@
+"""E2E test for verification_node with real Gemini API"""
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+import asyncio  # noqa: E402
+
+from graph.nodes.verification import verification_node  # noqa: E402
+from graph.state import PipelineSentence  # noqa: E402
+
+"""사용법(터미널): PYTHONPATH=src poetry run python scripts/test_verification_e2e.py"""
+
+
+async def test():
+    # 테스트할 claim 문장들 (sources 포함)
+    test_sentences: list[PipelineSentence] = [
+        {
+            "type": "claim",
+            "text": "비트코인은 2009년에 출시되었다.",
+            "startIndex": 0,
+            "endIndex": 20,
+            "retry_count": 0,
+            "sources": [
+                {
+                    "title": "Bitcoin Wikipedia",
+                    "url": "https://en.wikipedia.org/wiki/Bitcoin",
+                    "snippet": "Bitcoin was released as open-source software in January 2009.",
+                },
+                {
+                    "title": "사토시 나카모토",
+                    "url": "https://ko.wikipedia.org/wiki/비트코인",
+                    "snippet": "2009년 1월 3일에 첫 번째 블록(제네시스 블록)이 생성되었다.",
+                },
+            ],
+        },
+        {
+            "type": "claim",
+            "text": "비트코인은 2008년에 출시되었다.",  # FALSE expected
+            "startIndex": 21,
+            "endIndex": 40,
+            "retry_count": 0,
+            "sources": [
+                {
+                    "title": "Bitcoin History",
+                    "url": "https://example.com/bitcoin",
+                    "snippet": "Bitcoin was launched in January 2009 by Satoshi Nakamoto.",
+                },
+            ],
+        },
+        {
+            "type": "claim",
+            "text": "삼성전자는 1969년에 설립되었습니다.",
+            "startIndex": 41,
+            "endIndex": 60,
+            "retry_count": 0,
+            "sources": [
+                {
+                    "title": "삼성전자 공식 소개",
+                    "url": "https://www.samsung.com/sec/aboutsamsung/",
+                    "snippet": (
+                        "1969년에 설립된 삼성전자는 대한민국 경기도 수원에 본사를 두고 있습니다."
+                    ),
+                },
+            ],
+        },
+    ]
+
+    print("=" * 60)
+    print("Verification Node E2E Test (Real Gemini API)")
+    print("=" * 60)
+
+    for i, sentence in enumerate(test_sentences, 1):
+        print(f"\n[Test {i}] Claim: {sentence['text']}")
+        print(f"  Sources: {len(sentence.get('sources', []))}개")
+        print("-" * 40)
+
+        try:
+            result = await verification_node(sentence)
+
+            verdict = result.get("verdict", "N/A")
+            suggestion = result.get("suggestion")
+
+            if verdict == "TRUE":
+                print(f"  ✅ Verdict: {verdict}")
+            else:
+                print(f"  ❌ Verdict: {verdict}")
+                if suggestion:
+                    print(f"  💡 Suggestion: {suggestion}")
+
+        except Exception as e:
+            print(f"  ❌ Error: {e}")
+
+    print()
+    print("=" * 60)
+    print("Test completed!")
+    print("=" * 60)
+
+
+if __name__ == "__main__":
+    asyncio.run(test())

--- a/src/config.py
+++ b/src/config.py
@@ -1,1 +1,35 @@
-# 환경설정 (추후 pydantic-settings로 확장 가능)
+"""환경변수 설정 관리 - pydantic-settings 기반"""
+
+from functools import lru_cache
+
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class Settings(BaseSettings):
+    """
+    애플리케이션 설정 클래스.
+    환경변수 또는 .env 파일에서 설정값을 로드합니다.
+    """
+
+    model_config = SettingsConfigDict(
+        env_file=".env",
+        env_file_encoding="utf-8",
+    )
+
+    gemini_api_key: str
+    tavily_api_key: str
+    gemini_model: str = "gemini-2.5-flash-lite"
+
+
+@lru_cache(maxsize=1)
+def get_settings() -> Settings:
+    """
+    Settings 싱글톤 인스턴스를 반환합니다.
+
+    Returns:
+        Settings: 캐시된 설정 인스턴스
+
+    Raises:
+        ValidationError: 필수 환경변수가 누락된 경우
+    """
+    return Settings()

--- a/src/graph/nodes/extraction.py
+++ b/src/graph/nodes/extraction.py
@@ -1,21 +1,15 @@
-import os
-
 from graph.state import FactCheckState
-from services.llm import GeminiService
+from services.providers import get_gemini_service
 
 
 async def extraction_node(state: FactCheckState) -> FactCheckState:
     """
     Extraction Node: 텍스트에서 팩트체크가 필요한 문장을 추출
-    GeminiService를 사용해 실제 LLM 호출
+    GeminiService를 사용해 실제 LLM 호출 (싱글톤 인스턴스 사용)
     """
     original_text = state.get("original_text", "")
 
-    api_key = os.getenv("GEMINI_API_KEY")
-    if not api_key:
-        raise ValueError("GEMINI_API_KEY environment variable is required")
-
-    service = GeminiService(api_key=api_key)
+    service = get_gemini_service()
     result = await service.extract_sentences(original_text)
 
     return {"title": result["title"], "sentences": result["sentences"]}

--- a/src/graph/nodes/search.py
+++ b/src/graph/nodes/search.py
@@ -1,7 +1,5 @@
-import os
-
 from graph.state import PipelineSentence
-from services.search import TavilyService
+from services.providers import get_tavily_service
 
 
 async def search_node(sentence: PipelineSentence) -> PipelineSentence:
@@ -16,12 +14,8 @@ async def search_node(sentence: PipelineSentence) -> PipelineSentence:
         if "sources" in sentence and sentence["sources"]:
             sentence["retry_count"] += 1
 
-    # 2. TavilyService를 통한 검색 수행
-    api_key = os.getenv("TAVILY_API_KEY")
-    if not api_key:
-        raise ValueError("TAVILY_API_KEY environment variable is required")
-
-    service = TavilyService(api_key=api_key)
+    # 2. TavilyService를 통한 검색 수행 (싱글톤 인스턴스 사용)
+    service = get_tavily_service()
     sources = await service.search(
         query=sentence["text"],
         include_domains=sentence.get("whitelist", []),

--- a/src/graph/nodes/search.py
+++ b/src/graph/nodes/search.py
@@ -1,40 +1,34 @@
+import os
+
 from graph.state import PipelineSentence
+from services.search import TavilyService
 
 
 async def search_node(sentence: PipelineSentence) -> PipelineSentence:
     """
-    [MOCK]
     검색(Search)을 수행하는 노드입니다.
+    claim 문장에 대해 TavilyService를 통해 관련 소스를 검색합니다.
     """
 
     # 1. retry_count 증가 (재검색인 경우)
-    # workflow.py에서 초기화된 retry_count를 확인
     if "retry_count" in sentence:
-        # 이 노드가 호출되었다는 것은, 처음이거나 재시도 중이라는 뜻.
-        # 재시도 횟수를 여기서 증가시키면 다음 Verification 단계에서 확인 가능.
-        # 단, 첫 진입(Extraction 후)에는 0이어야 하는데,
-        # Loop를 돌아서 다시 Search로 오면 증가시켜야 함.
-        # 하지만 Graph 구조상 Search 노드는 매번 실행됨.
-        # 따라서 "Search 실행 횟수"를 세는 것이 됨.
-        # 검증 로직에서는 "이전까지의 시도 횟수"를 봐야 하므로,
-        # 검증 실패 후 다시 Search로 올 때 증가되어 있어야 함.
-        # 방법: 검증 실패 시 Conditional Edge에서 바로 Search로 보내는데,
-        # 이 때 상태를 변경할 수 없으므로, Search 노드 진입 시에
-        # "이게 재시도인가?"를 알아야 함.
-        # 판별법: sources가 이미 채워져 있으면 재시도임. (처음엔 비어있음)
+        # sources가 이미 채워져 있으면 재시도임
         if "sources" in sentence and sentence["sources"]:
             sentence["retry_count"] += 1
 
-    # 2. 검색 수행 (Mock)
-    # ... 실제 검색 API 호출 (비동기) ...
-    # 재검색 시 다른 검색어를 사용하거나 결과를 다르게 할 수 있음
-    sentence["sources"] = [
-        {
-            "title": "Trusted Source A",
-            "url": "https://example.com/a",
-            "snippet": f"This supports the claim X... (Retry: {sentence.get('retry_count', 0)})",
-        }
-    ]
+    # 2. TavilyService를 통한 검색 수행
+    api_key = os.getenv("TAVILY_API_KEY")
+    if not api_key:
+        raise ValueError("TAVILY_API_KEY environment variable is required")
 
-    # 순수 검색 노드이므로 검증 로직 호출 제거
+    service = TavilyService(api_key=api_key)
+    sources = await service.search(
+        query=sentence["text"],
+        include_domains=sentence.get("whitelist", []),
+        exclude_domains=sentence.get("blacklist", []),
+        max_results=5,
+    )
+
+    sentence["sources"] = sources
+
     return sentence

--- a/src/graph/nodes/verification.py
+++ b/src/graph/nodes/verification.py
@@ -1,23 +1,25 @@
+import os
+
 from graph.state import PipelineSentence
+from services.llm import GeminiService
 
 
 async def verification_node(sentence: PipelineSentence) -> PipelineSentence:
     """
-    [Logic]
-    단일 문장(PipelineSentence)과 소스(Sources)를 바탕으로 진실 여부를 판정합니다.
+    Verification Node: claim 문장과 sources를 바탕으로 진실 여부를 판정합니다.
+    GeminiService를 사용해 실제 LLM 호출
     """
+    api_key = os.getenv("GEMINI_API_KEY")
+    if not api_key:
+        raise ValueError("GEMINI_API_KEY environment variable is required")
 
-    # ... 실제 검증 API 호출 ...
+    service = GeminiService(api_key=api_key)
+    result = await service.verify_claim(
+        claim=sentence["text"],
+        sources=sentence.get("sources", []),
+    )
 
-    # PipelineSentence 구조에 맞춰 결과 업데이트
-    # 재검색 루프 테스트를 위해 특정 조건에서 FALSE 반환하도록 Mocking 가능
-    # 여기서는 retry_count가 0이면 FALSE, 1이상이면 TRUE로 하여 루프 동작 확인
-
-    if sentence.get("retry_count", 0) == 0:
-        sentence["verdict"] = "FALSE"
-        sentence["suggestion"] = "Need more evidence."
-    else:
-        sentence["verdict"] = "TRUE"
-        sentence["suggestion"] = None
+    sentence["verdict"] = result["verdict"]
+    sentence["suggestion"] = result.get("suggestion")
 
     return sentence

--- a/src/graph/nodes/verification.py
+++ b/src/graph/nodes/verification.py
@@ -1,19 +1,13 @@
-import os
-
 from graph.state import PipelineSentence
-from services.llm import GeminiService
+from services.providers import get_gemini_service
 
 
 async def verification_node(sentence: PipelineSentence) -> PipelineSentence:
     """
     Verification Node: claim 문장과 sources를 바탕으로 진실 여부를 판정합니다.
-    GeminiService를 사용해 실제 LLM 호출
+    GeminiService를 사용해 실제 LLM 호출 (싱글톤 인스턴스 사용)
     """
-    api_key = os.getenv("GEMINI_API_KEY")
-    if not api_key:
-        raise ValueError("GEMINI_API_KEY environment variable is required")
-
-    service = GeminiService(api_key=api_key)
+    service = get_gemini_service()
     result = await service.verify_claim(
         claim=sentence["text"],
         sources=sentence.get("sources", []),

--- a/src/graph/state.py
+++ b/src/graph/state.py
@@ -23,6 +23,10 @@ class PipelineSentence(TypedDict, total=False):
     endIndex: int
     retry_count: int  # 재검색 횟수 (기본값 0)
 
+    # ===== 검색 필터 (workflow에서 전달) =====
+    whitelist: list[str]  # 우선 검색 도메인
+    blacklist: list[str]  # 제외할 도메인
+
     # ===== opinion/excluded용 =====
     reason: str  # 의견/제외 분류 이유
 

--- a/src/graph/workflow.py
+++ b/src/graph/workflow.py
@@ -16,12 +16,17 @@ def continue_to_processing(state: FactCheckState):
     단, 'type'이 'claim'인 문장만 처리 대상으로 선정합니다.
     """
     start_nodes = []
+    whitelist = state.get("whitelist", [])
+    blacklist = state.get("blacklist", [])
 
     for s in state["sentences"]:
         if s.get("type") == "claim":
             # retry_count 초기화
             if "retry_count" not in s:
                 s["retry_count"] = 0
+            # whitelist/blacklist 전달
+            s["whitelist"] = whitelist
+            s["blacklist"] = blacklist
             start_nodes.append(Send("processing_node", s))
 
     return start_nodes

--- a/src/main.py
+++ b/src/main.py
@@ -1,4 +1,5 @@
-import os
+from collections.abc import AsyncGenerator
+from contextlib import asynccontextmanager
 from json import JSONDecodeError
 
 from dotenv import load_dotenv
@@ -6,6 +7,7 @@ from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
 from pydantic import ValidationError
 
+from config import get_settings
 from mcp import (
     JsonRpcError,
     JsonRpcErrorCode,
@@ -17,7 +19,15 @@ from mcp.router import route_request
 
 _ = load_dotenv()
 
-app = FastAPI(title="RT-Fact MCP Server")
+
+@asynccontextmanager
+async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
+    """앱 생명주기 관리 - 시작 시 환경변수 검증"""
+    get_settings()  # Fail-fast: 필수 환경변수 누락 시 즉시 실패
+    yield
+
+
+app = FastAPI(title="RT-Fact MCP Server", lifespan=lifespan)
 
 
 @app.get("/")
@@ -28,8 +38,12 @@ async def root():
 
 @app.get("/health")
 async def health_check():
-    """서버 상태 확인용 엔드포인트 (MCP-01 완료 조건)"""
-    has_api_key = os.getenv("GEMINI_API_KEY") or os.getenv("TAVILY_API_KEY")
+    """서버 상태 확인용 엔드포인트"""
+    try:
+        settings = get_settings()
+        has_api_key = bool(settings.gemini_api_key or settings.tavily_api_key)
+    except Exception:
+        has_api_key = False
     return {
         "status": "ok",
         "version": "0.1.0",

--- a/src/services/llm.py
+++ b/src/services/llm.py
@@ -22,6 +22,13 @@ class ExtractionResult(BaseModel):
     sentences: list[ExtractedSentence]
 
 
+class VerificationResult(BaseModel):
+    """검증 결과 스키마"""
+
+    verdict: Literal["TRUE", "FALSE"] = Field(description="사실 여부 판정")
+    suggestion: str | None = Field(default=None, description="FALSE 판정 시 수정 제안")
+
+
 EXTRACTION_PROMPT = """
 You are a fact-checking assistant that extracts and classifies sentences from text.
 

--- a/src/services/llm.py
+++ b/src/services/llm.py
@@ -6,6 +6,8 @@ from google import genai
 from google.genai import types
 from pydantic import BaseModel, Field
 
+from services.prompts import EXTRACTION_PROMPT, VERIFICATION_PROMPT
+
 
 class ExtractedSentence(BaseModel):
     """추출된 문장 스키마 (LLM 응답용 - 인덱스 없음)"""
@@ -27,52 +29,6 @@ class VerificationResult(BaseModel):
 
     verdict: Literal["TRUE", "FALSE"] = Field(description="사실 여부 판정")
     suggestion: str | None = Field(default=None, description="FALSE 판정 시 수정 제안")
-
-
-EXTRACTION_PROMPT = """
-You are a fact-checking assistant that extracts and classifies sentences from text.
-
-## Your Task
-1. Extract ALL sentences from the given text
-2. Classify each sentence into one of three categories
-3. Generate a concise title (max 15 characters) that summarizes the main topic
-
-## Classification Criteria
-
-### claim (Fact-checkable)
-Sentences containing objective, verifiable information:
-- Statistics, numbers, dates, measurements
-- Named entities (people, organizations, places)
-- Historical events or scientific facts
-- Statements that can be verified with external sources
-Examples: "The capital of Korea is Seoul.", "Bitcoin was launched in 2009."
-
-### opinion (Subjective)
-Sentences expressing personal views, judgments, or preferences:
-- Words like "should", "must", "need to" (normative statements)
-- Evaluative adjectives: "best", "worst", "beautiful", "terrible"
-- Predictions without factual basis
-- Personal feelings or beliefs
-Examples: "Seoul is a beautiful city.", "This policy will fail."
-
-### excluded (Not fact-checkable)
-Sentences that cannot or should not be fact-checked:
-- Greetings, farewells
-- Questions
-- Sentences with only pronouns (no clear referent)
-- Incomplete sentences or fragments
-- Commands or requests
-Examples: "Hello!", "What do you think?", "It is good." (unclear referent)
-
-## Output Requirements
-- text: MUST be the EXACT substring from the original text
-  (preserve all characters including punctuation)
-- reason: Required for opinion and excluded types (explain WHY in Korean, 1 sentence)
-- sentences: MUST be returned in the same order they appear in the original text
-
-## Text to Analyze
-{text}
-"""
 
 
 class GeminiService:
@@ -140,10 +96,31 @@ class GeminiService:
 
         Args:
             claim: 검증할 주장
-            sources: 검색된 소스 리스트
+            sources: 검색된 소스 리스트 [{"title": str, "url": str, "snippet": str}, ...]
 
         Returns:
-            검증 결과 (verdict: TRUE/FALSE, suggestion?)
+            {"verdict": "TRUE" | "FALSE", "suggestion": str | None}
         """
-        # TODO: Gemini API 호출
-        pass
+
+        # sources를 문자열로 포맷팅
+        sources_text = "\n\n".join(
+            f"### {s.get('title', 'Untitled')}\n"
+            f"URL: {s.get('url', 'N/A')}\n"
+            f"Content: {s.get('snippet', '')}"
+            for s in sources
+        )
+
+        prompt = VERIFICATION_PROMPT.format(claim=claim, sources=sources_text)
+
+        response = await self.client.aio.models.generate_content(
+            model=self.model,
+            contents=prompt,
+            config=types.GenerateContentConfig(
+                response_mime_type="application/json",
+                response_schema=VerificationResult,
+                temperature=0.1,
+            ),
+        )
+
+        result = VerificationResult.model_validate_json(response.text)
+        return result.model_dump(exclude_none=True)

--- a/src/services/llm_spec.py
+++ b/src/services/llm_spec.py
@@ -52,6 +52,56 @@ async def test_gemini_service_verify_claim(mocker):
 
 
 @pytest.mark.asyncio
+async def test_verify_claim_true_verdict(mocker):
+    """TRUE 판정 시 suggestion이 None인지 테스트"""
+    mock_llm_result = llm.VerificationResult(verdict="TRUE", suggestion=None)
+
+    mock_api_response = MagicMock()
+    mock_api_response.text = mock_llm_result.model_dump_json()
+
+    mock_client = MagicMock()
+    mock_client.aio.models.generate_content = AsyncMock(return_value=mock_api_response)
+    mocker.patch.object(llm.genai, "Client", return_value=mock_client)
+
+    service = llm.GeminiService(api_key="test-key")
+    result = await service.verify_claim(
+        claim="서울은 대한민국의 수도이다.",
+        sources=[
+            {"title": "Wikipedia", "url": "https://...", "snippet": "서울은 대한민국의 수도..."}
+        ],
+    )
+
+    assert result["verdict"] == "TRUE"
+    assert "suggestion" not in result  # exclude_none=True이므로 None은 제외됨
+
+
+@pytest.mark.asyncio
+async def test_verify_claim_false_verdict_with_suggestion(mocker):
+    """FALSE 판정 시 suggestion이 포함되는지 테스트"""
+    mock_llm_result = llm.VerificationResult(
+        verdict="FALSE", suggestion="비트코인은 2008년이 아닌 2009년에 출시되었습니다."
+    )
+
+    mock_api_response = MagicMock()
+    mock_api_response.text = mock_llm_result.model_dump_json()
+
+    mock_client = MagicMock()
+    mock_client.aio.models.generate_content = AsyncMock(return_value=mock_api_response)
+    mocker.patch.object(llm.genai, "Client", return_value=mock_client)
+
+    service = llm.GeminiService(api_key="test-key")
+    result = await service.verify_claim(
+        claim="비트코인은 2008년에 출시되었다.",
+        sources=[
+            {"title": "Bitcoin Wiki", "url": "https://...", "snippet": "2009년 1월에 출시..."}
+        ],
+    )
+
+    assert result["verdict"] == "FALSE"
+    assert result["suggestion"] == "비트코인은 2008년이 아닌 2009년에 출시되었습니다."
+
+
+@pytest.mark.asyncio
 async def test_extract_sentences_index_calculation(mocker):
     """인덱스 계산 로직 테스트 - 원본 텍스트에서 문장 위치 정확도"""
     # 원본 텍스트

--- a/src/services/prompts.py
+++ b/src/services/prompts.py
@@ -1,0 +1,82 @@
+"""LLM 프롬프트 템플릿 모듈"""
+
+EXTRACTION_PROMPT = """
+You are a fact-checking assistant that extracts and classifies sentences from text.
+
+## Your Task
+1. Extract ALL sentences from the given text
+2. Classify each sentence into one of three categories
+3. Generate a concise title (max 15 characters) that summarizes the main topic
+
+## Classification Criteria
+
+### claim (Fact-checkable)
+Sentences containing objective, verifiable information:
+- Statistics, numbers, dates, measurements
+- Named entities (people, organizations, places)
+- Historical events or scientific facts
+- Statements that can be verified with external sources
+Examples: "The capital of Korea is Seoul.", "Bitcoin was launched in 2009."
+
+### opinion (Subjective)
+Sentences expressing personal views, judgments, or preferences:
+- Words like "should", "must", "need to" (normative statements)
+- Evaluative adjectives: "best", "worst", "beautiful", "terrible"
+- Predictions without factual basis
+- Personal feelings or beliefs
+Examples: "Seoul is a beautiful city.", "This policy will fail."
+
+### excluded (Not fact-checkable)
+Sentences that cannot or should not be fact-checked:
+- Greetings, farewells
+- Questions
+- Sentences with only pronouns (no clear referent)
+- Incomplete sentences or fragments
+- Commands or requests
+Examples: "Hello!", "What do you think?", "It is good." (unclear referent)
+
+## Output Requirements
+- text: MUST be the EXACT substring from the original text
+  (preserve all characters including punctuation)
+- reason: Required for opinion and excluded types (explain WHY in Korean, 1 sentence)
+- sentences: MUST be returned in the same order they appear in the original text
+
+## Text to Analyze
+{text}
+"""
+
+
+VERIFICATION_PROMPT = """
+You are a fact-checking assistant that verifies claims against source materials.
+
+## Your Task
+Determine whether the given claim is TRUE or FALSE based on the provided sources.
+
+## Input
+- **Claim**: The statement to verify
+- **Sources**: Reference materials with titles, URLs, and content snippets
+
+## Verification Rules
+1. A claim is TRUE if:
+   - The sources provide clear evidence supporting the claim
+   - The information in sources matches the claim's content
+
+2. A claim is FALSE if:
+   - The sources contradict the claim
+   - The sources provide different/updated information
+   - There is insufficient evidence to support the claim
+
+## Output Requirements
+- verdict: "TRUE" or "FALSE"
+- suggestion: 
+  - If TRUE: Must be null
+  - If FALSE: Provide a specific correction in Korean (1-2 sentences)
+    - Explain what is incorrect
+    - Suggest what the correct information is based on sources
+
+## Claim to Verify
+{claim}
+
+## Sources
+{sources}
+"""

--- a/src/services/providers.py
+++ b/src/services/providers.py
@@ -1,0 +1,41 @@
+"""Service Provider 함수들 - 싱글톤 패턴으로 서비스 인스턴스 제공"""
+
+import os
+from functools import lru_cache
+
+from services.llm import GeminiService
+from services.search import TavilyService
+
+
+@lru_cache(maxsize=1)
+def get_tavily_service() -> TavilyService:
+    """
+    TavilyService 싱글톤 인스턴스를 반환합니다.
+
+    Returns:
+        TavilyService: 캐시된 서비스 인스턴스
+
+    Raises:
+        ValueError: TAVILY_API_KEY 환경변수가 없는 경우
+    """
+    api_key = os.getenv("TAVILY_API_KEY")
+    if not api_key:
+        raise ValueError("TAVILY_API_KEY environment variable is required")
+    return TavilyService(api_key=api_key)
+
+
+@lru_cache(maxsize=1)
+def get_gemini_service() -> GeminiService:
+    """
+    GeminiService 싱글톤 인스턴스를 반환합니다.
+
+    Returns:
+        GeminiService: 캐시된 서비스 인스턴스
+
+    Raises:
+        ValueError: GEMINI_API_KEY 환경변수가 없는 경우
+    """
+    api_key = os.getenv("GEMINI_API_KEY")
+    if not api_key:
+        raise ValueError("GEMINI_API_KEY environment variable is required")
+    return GeminiService(api_key=api_key)

--- a/src/services/providers.py
+++ b/src/services/providers.py
@@ -1,8 +1,8 @@
 """Service Provider 함수들 - 싱글톤 패턴으로 서비스 인스턴스 제공"""
 
-import os
 from functools import lru_cache
 
+from config import get_settings
 from services.llm import GeminiService
 from services.search import TavilyService
 
@@ -14,14 +14,9 @@ def get_tavily_service() -> TavilyService:
 
     Returns:
         TavilyService: 캐시된 서비스 인스턴스
-
-    Raises:
-        ValueError: TAVILY_API_KEY 환경변수가 없는 경우
     """
-    api_key = os.getenv("TAVILY_API_KEY")
-    if not api_key:
-        raise ValueError("TAVILY_API_KEY environment variable is required")
-    return TavilyService(api_key=api_key)
+    settings = get_settings()
+    return TavilyService(api_key=settings.tavily_api_key)
 
 
 @lru_cache(maxsize=1)
@@ -31,11 +26,6 @@ def get_gemini_service() -> GeminiService:
 
     Returns:
         GeminiService: 캐시된 서비스 인스턴스
-
-    Raises:
-        ValueError: GEMINI_API_KEY 환경변수가 없는 경우
     """
-    api_key = os.getenv("GEMINI_API_KEY")
-    if not api_key:
-        raise ValueError("GEMINI_API_KEY environment variable is required")
-    return GeminiService(api_key=api_key)
+    settings = get_settings()
+    return GeminiService(api_key=settings.gemini_api_key)

--- a/src/services/search.py
+++ b/src/services/search.py
@@ -4,6 +4,9 @@ from tavily import AsyncTavilyClient
 
 from graph.state import Source
 
+# Snippet 최대 길이 (검색 결과 미리보기용)
+SNIPPET_MAX_LENGTH = 200
+
 
 class TavilyService:
     """Tavily Search API 래퍼 클래스"""
@@ -50,7 +53,7 @@ class TavilyService:
                 Source(
                     title=result.get("title", ""),
                     url=result.get("url", ""),
-                    snippet=result.get("content", "")[:200],
+                    snippet=result.get("content", "")[:SNIPPET_MAX_LENGTH],
                 )
             )
 

--- a/src/services/search.py
+++ b/src/services/search.py
@@ -1,6 +1,6 @@
 """Tavily Search API 서비스 래퍼"""
 
-from tavily import TavilyClient
+from tavily import AsyncTavilyClient
 
 from graph.state import Source
 
@@ -13,7 +13,7 @@ class TavilyService:
         Args:
             api_key: Tavily API 키
         """
-        self.client = TavilyClient(api_key=api_key)
+        self.client = AsyncTavilyClient(api_key=api_key)
 
     async def search(
         self,
@@ -36,5 +36,22 @@ class TavilyService:
         """
         include_domains = include_domains or []
         exclude_domains = exclude_domains or []
-        # TODO: Tavily API 호출
-        pass
+
+        response = await self.client.search(
+            query=query,
+            max_results=max_results,
+            include_domains=include_domains if include_domains else None,
+            exclude_domains=exclude_domains if exclude_domains else None,
+        )
+
+        sources: list[Source] = []
+        for result in response.get("results", []):
+            sources.append(
+                Source(
+                    title=result.get("title", ""),
+                    url=result.get("url", ""),
+                    snippet=result.get("content", "")[:200],
+                )
+            )
+
+        return sources

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,12 @@
 """pytest 공통 fixture 설정"""
 
+from unittest.mock import MagicMock, patch
+
 import pytest
 
+from services.llm import GeminiService
 from services.providers import get_gemini_service, get_tavily_service
+from services.search import TavilyService
 
 
 @pytest.fixture(autouse=True)
@@ -11,12 +15,44 @@ def clear_service_cache():
     각 테스트 전후로 서비스 싱글톤 캐시를 초기화합니다.
     테스트 간 상태 격리를 보장합니다.
     """
-    # 테스트 전: 캐시 초기화
     get_tavily_service.cache_clear()
     get_gemini_service.cache_clear()
 
     yield
 
-    # 테스트 후: 캐시 초기화
     get_tavily_service.cache_clear()
     get_gemini_service.cache_clear()
+
+
+@pytest.fixture
+def mock_gemini_service():
+    """
+    GeminiService mock fixture.
+    extraction, verification 노드 테스트용.
+
+    Usage:
+        def test_something(mock_gemini_service):
+            mock_gemini_service.extract_sentences = AsyncMock(return_value={...})
+            mock_gemini_service.verify_claim = AsyncMock(return_value={...})
+    """
+    mock = MagicMock(spec=GeminiService)
+    with (
+        patch("graph.nodes.extraction.get_gemini_service", return_value=mock),
+        patch("graph.nodes.verification.get_gemini_service", return_value=mock),
+    ):
+        yield mock
+
+
+@pytest.fixture
+def mock_tavily_service():
+    """
+    TavilyService mock fixture.
+    search 노드 테스트용.
+
+    Usage:
+        def test_something(mock_tavily_service):
+            mock_tavily_service.search = AsyncMock(return_value=[...])
+    """
+    mock = MagicMock(spec=TavilyService)
+    with patch("graph.nodes.search.get_tavily_service", return_value=mock):
+        yield mock

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,22 @@
+"""pytest 공통 fixture 설정"""
+
+import pytest
+
+from services.providers import get_gemini_service, get_tavily_service
+
+
+@pytest.fixture(autouse=True)
+def clear_service_cache():
+    """
+    각 테스트 전후로 서비스 싱글톤 캐시를 초기화합니다.
+    테스트 간 상태 격리를 보장합니다.
+    """
+    # 테스트 전: 캐시 초기화
+    get_tavily_service.cache_clear()
+    get_gemini_service.cache_clear()
+
+    yield
+
+    # 테스트 후: 캐시 초기화
+    get_tavily_service.cache_clear()
+    get_gemini_service.cache_clear()

--- a/tests/graph/nodes_spec.py
+++ b/tests/graph/nodes_spec.py
@@ -1,11 +1,13 @@
 """Mock 노드 단위 테스트"""
 
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from graph.nodes import extraction, search, verification
 from graph.state import FactCheckState, PipelineSentence
+from services.llm import GeminiService
+from services.search import TavilyService
 
 
 @pytest.mark.asyncio
@@ -26,10 +28,11 @@ async def test_extraction_node():
         ],
     }
 
+    mock_service = MagicMock(spec=GeminiService)
+    mock_service.extract_sentences = AsyncMock(return_value=mock_result)
+
     with patch.dict("os.environ", {"GEMINI_API_KEY": "test-key"}):
-        with patch.object(
-            extraction.GeminiService, "extract_sentences", new=AsyncMock(return_value=mock_result)
-        ):
+        with patch("graph.nodes.extraction.get_gemini_service", return_value=mock_service):
             new_state = await extraction.extraction_node(initial_state)
 
     assert len(new_state["sentences"]) > 0
@@ -53,8 +56,11 @@ async def test_search_node():
 
     mock_sources = [{"title": "Test", "url": "https://test.com", "snippet": "테스트 결과"}]
 
+    mock_service = MagicMock(spec=TavilyService)
+    mock_service.search = AsyncMock(return_value=mock_sources)
+
     with patch.dict("os.environ", {"TAVILY_API_KEY": "test-key"}):
-        with patch.object(search.TavilyService, "search", new=AsyncMock(return_value=mock_sources)):
+        with patch("graph.nodes.search.get_tavily_service", return_value=mock_service):
             result = await search.search_node(sentence)
 
     assert "sources" in result
@@ -77,8 +83,11 @@ async def test_search_node_retry():
 
     mock_sources = [{"title": "New", "url": "https://new.com", "snippet": "새 결과"}]
 
+    mock_service = MagicMock(spec=TavilyService)
+    mock_service.search = AsyncMock(return_value=mock_sources)
+
     with patch.dict("os.environ", {"TAVILY_API_KEY": "test-key"}):
-        with patch.object(search.TavilyService, "search", new=AsyncMock(return_value=mock_sources)):
+        with patch("graph.nodes.search.get_tavily_service", return_value=mock_service):
             result = await search.search_node(sentence)
 
     assert result["retry_count"] == 1  # 증가했어야 함
@@ -101,8 +110,11 @@ async def test_search_node_with_domain_filters():
     mock_sources = [{"title": "Test", "url": "https://trusted.com", "snippet": "결과"}]
     mock_search = AsyncMock(return_value=mock_sources)
 
+    mock_service = MagicMock(spec=TavilyService)
+    mock_service.search = mock_search
+
     with patch.dict("os.environ", {"TAVILY_API_KEY": "test-key"}):
-        with patch.object(search.TavilyService, "search", mock_search):
+        with patch("graph.nodes.search.get_tavily_service", return_value=mock_service):
             await search.search_node(sentence)
 
     # TavilyService.search()에 도메인 필터가 전달되었는지 확인
@@ -128,10 +140,11 @@ async def test_verification_node_true():
 
     mock_result = {"verdict": "TRUE"}
 
+    mock_service = MagicMock(spec=GeminiService)
+    mock_service.verify_claim = AsyncMock(return_value=mock_result)
+
     with patch.dict("os.environ", {"GEMINI_API_KEY": "test-key"}):
-        with patch.object(
-            verification.GeminiService, "verify_claim", new=AsyncMock(return_value=mock_result)
-        ):
+        with patch("graph.nodes.verification.get_gemini_service", return_value=mock_service):
             result = await verification.verification_node(sentence)
 
     assert result["verdict"] == "TRUE"
@@ -152,10 +165,11 @@ async def test_verification_node_false_with_suggestion():
 
     mock_result = {"verdict": "FALSE", "suggestion": "비트코인은 2009년에 출시되었습니다."}
 
+    mock_service = MagicMock(spec=GeminiService)
+    mock_service.verify_claim = AsyncMock(return_value=mock_result)
+
     with patch.dict("os.environ", {"GEMINI_API_KEY": "test-key"}):
-        with patch.object(
-            verification.GeminiService, "verify_claim", new=AsyncMock(return_value=mock_result)
-        ):
+        with patch("graph.nodes.verification.get_gemini_service", return_value=mock_service):
             result = await verification.verification_node(sentence)
 
     assert result["verdict"] == "FALSE"

--- a/tests/graph/nodes_spec.py
+++ b/tests/graph/nodes_spec.py
@@ -51,7 +51,11 @@ async def test_search_node():
         "retry_count": 0,
     }
 
-    result = await search.search_node(sentence)
+    mock_sources = [{"title": "Test", "url": "https://test.com", "snippet": "테스트 결과"}]
+
+    with patch.dict("os.environ", {"TAVILY_API_KEY": "test-key"}):
+        with patch.object(search.TavilyService, "search", new=AsyncMock(return_value=mock_sources)):
+            result = await search.search_node(sentence)
 
     assert "sources" in result
     assert len(result["sources"]) > 0
@@ -71,7 +75,11 @@ async def test_search_node_retry():
         "sources": [{"title": "Old", "url": "url", "snippet": "old"}],
     }
 
-    result = await search.search_node(sentence)
+    mock_sources = [{"title": "New", "url": "https://new.com", "snippet": "새 결과"}]
+
+    with patch.dict("os.environ", {"TAVILY_API_KEY": "test-key"}):
+        with patch.object(search.TavilyService, "search", new=AsyncMock(return_value=mock_sources)):
+            result = await search.search_node(sentence)
 
     assert result["retry_count"] == 1  # 증가했어야 함
     assert "sources" in result  # 검색 다시 수행됨

--- a/tests/graph/nodes_spec.py
+++ b/tests/graph/nodes_spec.py
@@ -1,17 +1,15 @@
 """Mock 노드 단위 테스트"""
 
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock
 
 import pytest
 
 from graph.nodes import extraction, search, verification
 from graph.state import FactCheckState, PipelineSentence
-from services.llm import GeminiService
-from services.search import TavilyService
 
 
 @pytest.mark.asyncio
-async def test_extraction_node():
+async def test_extraction_node(mock_gemini_service):
     """Extraction 노드가 PipelineSentence를 잘 생성하는지 테스트"""
     initial_state: FactCheckState = {
         "original_text": "테스트 텍스트",
@@ -28,12 +26,9 @@ async def test_extraction_node():
         ],
     }
 
-    mock_service = MagicMock(spec=GeminiService)
-    mock_service.extract_sentences = AsyncMock(return_value=mock_result)
+    mock_gemini_service.extract_sentences = AsyncMock(return_value=mock_result)
 
-    with patch.dict("os.environ", {"GEMINI_API_KEY": "test-key"}):
-        with patch("graph.nodes.extraction.get_gemini_service", return_value=mock_service):
-            new_state = await extraction.extraction_node(initial_state)
+    new_state = await extraction.extraction_node(initial_state)
 
     assert len(new_state["sentences"]) > 0
     first_sent = new_state["sentences"][0]
@@ -43,9 +38,8 @@ async def test_extraction_node():
 
 
 @pytest.mark.asyncio
-async def test_search_node():
+async def test_search_node(mock_tavily_service):
     """Search 노드가 검색을 수행하고 sources를 추가하는지 테스트"""
-    # 초기 상태 (첫 진입)
     sentence: PipelineSentence = {
         "type": "claim",
         "text": "테스트 주장",
@@ -55,13 +49,9 @@ async def test_search_node():
     }
 
     mock_sources = [{"title": "Test", "url": "https://test.com", "snippet": "테스트 결과"}]
+    mock_tavily_service.search = AsyncMock(return_value=mock_sources)
 
-    mock_service = MagicMock(spec=TavilyService)
-    mock_service.search = AsyncMock(return_value=mock_sources)
-
-    with patch.dict("os.environ", {"TAVILY_API_KEY": "test-key"}):
-        with patch("graph.nodes.search.get_tavily_service", return_value=mock_service):
-            result = await search.search_node(sentence)
+    result = await search.search_node(sentence)
 
     assert "sources" in result
     assert len(result["sources"]) > 0
@@ -69,9 +59,8 @@ async def test_search_node():
 
 
 @pytest.mark.asyncio
-async def test_search_node_retry():
+async def test_search_node_retry(mock_tavily_service):
     """Search 노드가 재진입 시 retry_count를 증가시키는지 테스트"""
-    # 재진입 상태 (이미 sources가 있음)
     sentence: PipelineSentence = {
         "type": "claim",
         "text": "테스트 주장",
@@ -82,20 +71,16 @@ async def test_search_node_retry():
     }
 
     mock_sources = [{"title": "New", "url": "https://new.com", "snippet": "새 결과"}]
+    mock_tavily_service.search = AsyncMock(return_value=mock_sources)
 
-    mock_service = MagicMock(spec=TavilyService)
-    mock_service.search = AsyncMock(return_value=mock_sources)
-
-    with patch.dict("os.environ", {"TAVILY_API_KEY": "test-key"}):
-        with patch("graph.nodes.search.get_tavily_service", return_value=mock_service):
-            result = await search.search_node(sentence)
+    result = await search.search_node(sentence)
 
     assert result["retry_count"] == 1  # 증가했어야 함
     assert "sources" in result  # 검색 다시 수행됨
 
 
 @pytest.mark.asyncio
-async def test_search_node_with_domain_filters():
+async def test_search_node_with_domain_filters(mock_tavily_service):
     """Search 노드가 whitelist/blacklist를 TavilyService에 전달하는지 테스트"""
     sentence: PipelineSentence = {
         "type": "claim",
@@ -109,13 +94,9 @@ async def test_search_node_with_domain_filters():
 
     mock_sources = [{"title": "Test", "url": "https://trusted.com", "snippet": "결과"}]
     mock_search = AsyncMock(return_value=mock_sources)
+    mock_tavily_service.search = mock_search
 
-    mock_service = MagicMock(spec=TavilyService)
-    mock_service.search = mock_search
-
-    with patch.dict("os.environ", {"TAVILY_API_KEY": "test-key"}):
-        with patch("graph.nodes.search.get_tavily_service", return_value=mock_service):
-            await search.search_node(sentence)
+    await search.search_node(sentence)
 
     # TavilyService.search()에 도메인 필터가 전달되었는지 확인
     mock_search.assert_called_once_with(
@@ -127,7 +108,7 @@ async def test_search_node_with_domain_filters():
 
 
 @pytest.mark.asyncio
-async def test_verification_node_true():
+async def test_verification_node_true(mock_gemini_service):
     """Verification 노드가 TRUE verdict를 설정하는지 테스트"""
     sentence: PipelineSentence = {
         "type": "claim",
@@ -139,20 +120,16 @@ async def test_verification_node_true():
     }
 
     mock_result = {"verdict": "TRUE"}
+    mock_gemini_service.verify_claim = AsyncMock(return_value=mock_result)
 
-    mock_service = MagicMock(spec=GeminiService)
-    mock_service.verify_claim = AsyncMock(return_value=mock_result)
-
-    with patch.dict("os.environ", {"GEMINI_API_KEY": "test-key"}):
-        with patch("graph.nodes.verification.get_gemini_service", return_value=mock_service):
-            result = await verification.verification_node(sentence)
+    result = await verification.verification_node(sentence)
 
     assert result["verdict"] == "TRUE"
     assert result["suggestion"] is None
 
 
 @pytest.mark.asyncio
-async def test_verification_node_false_with_suggestion():
+async def test_verification_node_false_with_suggestion(mock_gemini_service):
     """Verification 노드가 FALSE verdict와 suggestion을 설정하는지 테스트"""
     sentence: PipelineSentence = {
         "type": "claim",
@@ -164,13 +141,9 @@ async def test_verification_node_false_with_suggestion():
     }
 
     mock_result = {"verdict": "FALSE", "suggestion": "비트코인은 2009년에 출시되었습니다."}
+    mock_gemini_service.verify_claim = AsyncMock(return_value=mock_result)
 
-    mock_service = MagicMock(spec=GeminiService)
-    mock_service.verify_claim = AsyncMock(return_value=mock_result)
-
-    with patch.dict("os.environ", {"GEMINI_API_KEY": "test-key"}):
-        with patch("graph.nodes.verification.get_gemini_service", return_value=mock_service):
-            result = await verification.verification_node(sentence)
+    result = await verification.verification_node(sentence)
 
     assert result["verdict"] == "FALSE"
     assert result["suggestion"] == "비트코인은 2009년에 출시되었습니다."

--- a/tests/graph/nodes_spec.py
+++ b/tests/graph/nodes_spec.py
@@ -86,6 +86,35 @@ async def test_search_node_retry():
 
 
 @pytest.mark.asyncio
+async def test_search_node_with_domain_filters():
+    """Search 노드가 whitelist/blacklist를 TavilyService에 전달하는지 테스트"""
+    sentence: PipelineSentence = {
+        "type": "claim",
+        "text": "테스트 주장",
+        "startIndex": 0,
+        "endIndex": 5,
+        "retry_count": 0,
+        "whitelist": ["trusted.com", "reliable.org"],
+        "blacklist": ["spam.com"],
+    }
+
+    mock_sources = [{"title": "Test", "url": "https://trusted.com", "snippet": "결과"}]
+    mock_search = AsyncMock(return_value=mock_sources)
+
+    with patch.dict("os.environ", {"TAVILY_API_KEY": "test-key"}):
+        with patch.object(search.TavilyService, "search", mock_search):
+            await search.search_node(sentence)
+
+    # TavilyService.search()에 도메인 필터가 전달되었는지 확인
+    mock_search.assert_called_once_with(
+        query="테스트 주장",
+        include_domains=["trusted.com", "reliable.org"],
+        exclude_domains=["spam.com"],
+        max_results=5,
+    )
+
+
+@pytest.mark.asyncio
 async def test_verification_node():
     """Verification 노드가 verdict를 설정하는지 테스트"""
     sentence: PipelineSentence = {

--- a/tests/graph/nodes_spec.py
+++ b/tests/graph/nodes_spec.py
@@ -115,8 +115,8 @@ async def test_search_node_with_domain_filters():
 
 
 @pytest.mark.asyncio
-async def test_verification_node():
-    """Verification 노드가 verdict를 설정하는지 테스트"""
+async def test_verification_node_true():
+    """Verification 노드가 TRUE verdict를 설정하는지 테스트"""
     sentence: PipelineSentence = {
         "type": "claim",
         "text": "테스트 주장",
@@ -126,11 +126,37 @@ async def test_verification_node():
         "retry_count": 0,
     }
 
-    # retry_count가 0이면 Mock 로직상 FALSE
-    result_false = await verification.verification_node(sentence)
-    assert result_false["verdict"] == "FALSE"
+    mock_result = {"verdict": "TRUE"}
 
-    # retry_count가 1이면 Mock 로직상 TRUE
-    sentence["retry_count"] = 1
-    result_true = await verification.verification_node(sentence)
-    assert result_true["verdict"] == "TRUE"
+    with patch.dict("os.environ", {"GEMINI_API_KEY": "test-key"}):
+        with patch.object(
+            verification.GeminiService, "verify_claim", new=AsyncMock(return_value=mock_result)
+        ):
+            result = await verification.verification_node(sentence)
+
+    assert result["verdict"] == "TRUE"
+    assert result["suggestion"] is None
+
+
+@pytest.mark.asyncio
+async def test_verification_node_false_with_suggestion():
+    """Verification 노드가 FALSE verdict와 suggestion을 설정하는지 테스트"""
+    sentence: PipelineSentence = {
+        "type": "claim",
+        "text": "비트코인은 2008년에 출시되었다.",
+        "startIndex": 0,
+        "endIndex": 20,
+        "sources": [{"title": "Bitcoin Wiki", "url": "https://...", "snippet": "2009년 출시..."}],
+        "retry_count": 0,
+    }
+
+    mock_result = {"verdict": "FALSE", "suggestion": "비트코인은 2009년에 출시되었습니다."}
+
+    with patch.dict("os.environ", {"GEMINI_API_KEY": "test-key"}):
+        with patch.object(
+            verification.GeminiService, "verify_claim", new=AsyncMock(return_value=mock_result)
+        ):
+            result = await verification.verification_node(sentence)
+
+    assert result["verdict"] == "FALSE"
+    assert result["suggestion"] == "비트코인은 2009년에 출시되었습니다."

--- a/tests/graph/workflow_spec.py
+++ b/tests/graph/workflow_spec.py
@@ -4,7 +4,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from graph.nodes import extraction
+from graph.nodes import extraction, search
 from graph.state import FactCheckState
 from graph.workflow import create_graph
 
@@ -16,8 +16,8 @@ async def test_factcheck_workflow():
 
     initial_state: FactCheckState = {
         "original_text": "AI is changing the world.",
-        "whitelist": [],
-        "blacklist": [],
+        "whitelist": ["trusted.com"],
+        "blacklist": ["spam.com"],
         "title": "",
         "sentences": [],
     }
@@ -43,13 +43,22 @@ async def test_factcheck_workflow():
         ],
     }
 
-    with patch.dict("os.environ", {"GEMINI_API_KEY": "test-key"}):
+    mock_search_result = [
+        {"title": "AI News", "url": "https://trusted.com/ai", "snippet": "AI impact..."}
+    ]
+
+    with patch.dict("os.environ", {"GEMINI_API_KEY": "test-key", "TAVILY_API_KEY": "test-key"}):
         with patch.object(
             extraction.GeminiService,
             "extract_sentences",
             new=AsyncMock(return_value=mock_extraction_result),
         ):
-            final_state = await workflow.ainvoke(initial_state)
+            with patch.object(
+                search.TavilyService,
+                "search",
+                new=AsyncMock(return_value=mock_search_result),
+            ):
+                final_state = await workflow.ainvoke(initial_state)
 
     # 1. Title 생성 확인
     assert final_state["title"].startswith("Topic:")

--- a/tests/graph/workflow_spec.py
+++ b/tests/graph/workflow_spec.py
@@ -1,12 +1,13 @@
 """LangGraph 워크플로우 통합 테스트 (Mock)"""
 
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from graph.nodes import extraction, search, verification
 from graph.state import FactCheckState
 from graph.workflow import create_graph
+from services.llm import GeminiService
+from services.search import TavilyService
 
 
 @pytest.mark.asyncio
@@ -50,29 +51,25 @@ async def test_factcheck_workflow():
     # verify_claim mock - 첫 호출은 FALSE, 이후는 TRUE (retry loop 테스트)
     verify_call_count = 0
 
-    async def mock_verify_claim(self, claim, sources):
+    async def mock_verify_claim(claim, sources):
         nonlocal verify_call_count
         verify_call_count += 1
         if verify_call_count == 1:
             return {"verdict": "FALSE", "suggestion": "Need more evidence."}
         return {"verdict": "TRUE"}
 
+    # Mock services
+    mock_gemini = MagicMock(spec=GeminiService)
+    mock_gemini.extract_sentences = AsyncMock(return_value=mock_extraction_result)
+    mock_gemini.verify_claim = mock_verify_claim
+
+    mock_tavily = MagicMock(spec=TavilyService)
+    mock_tavily.search = AsyncMock(return_value=mock_search_result)
+
     with patch.dict("os.environ", {"GEMINI_API_KEY": "test-key", "TAVILY_API_KEY": "test-key"}):
-        with patch.object(
-            extraction.GeminiService,
-            "extract_sentences",
-            new=AsyncMock(return_value=mock_extraction_result),
-        ):
-            with patch.object(
-                search.TavilyService,
-                "search",
-                new=AsyncMock(return_value=mock_search_result),
-            ):
-                with patch.object(
-                    verification.GeminiService,
-                    "verify_claim",
-                    new=mock_verify_claim,
-                ):
+        with patch("graph.nodes.extraction.get_gemini_service", return_value=mock_gemini):
+            with patch("graph.nodes.verification.get_gemini_service", return_value=mock_gemini):
+                with patch("graph.nodes.search.get_tavily_service", return_value=mock_tavily):
                     final_state = await workflow.ainvoke(initial_state)
 
     # 1. Title 생성 확인

--- a/tests/graph/workflow_spec.py
+++ b/tests/graph/workflow_spec.py
@@ -1,17 +1,15 @@
 """LangGraph 워크플로우 통합 테스트 (Mock)"""
 
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock
 
 import pytest
 
 from graph.state import FactCheckState
 from graph.workflow import create_graph
-from services.llm import GeminiService
-from services.search import TavilyService
 
 
 @pytest.mark.asyncio
-async def test_factcheck_workflow():
+async def test_factcheck_workflow(mock_gemini_service, mock_tavily_service):
     """전체 워크플로우(Graph) 실행 테스트 (Async)"""
     workflow = create_graph()
 
@@ -23,8 +21,7 @@ async def test_factcheck_workflow():
         "sentences": [],
     }
 
-    # ainvoke (Async Invoke) 사용
-
+    # Mock extraction result
     mock_extraction_result = {
         "title": "Topic: AI Impact",
         "sentences": [
@@ -58,19 +55,12 @@ async def test_factcheck_workflow():
             return {"verdict": "FALSE", "suggestion": "Need more evidence."}
         return {"verdict": "TRUE"}
 
-    # Mock services
-    mock_gemini = MagicMock(spec=GeminiService)
-    mock_gemini.extract_sentences = AsyncMock(return_value=mock_extraction_result)
-    mock_gemini.verify_claim = mock_verify_claim
+    # Configure mock services
+    mock_gemini_service.extract_sentences = AsyncMock(return_value=mock_extraction_result)
+    mock_gemini_service.verify_claim = mock_verify_claim
+    mock_tavily_service.search = AsyncMock(return_value=mock_search_result)
 
-    mock_tavily = MagicMock(spec=TavilyService)
-    mock_tavily.search = AsyncMock(return_value=mock_search_result)
-
-    with patch.dict("os.environ", {"GEMINI_API_KEY": "test-key", "TAVILY_API_KEY": "test-key"}):
-        with patch("graph.nodes.extraction.get_gemini_service", return_value=mock_gemini):
-            with patch("graph.nodes.verification.get_gemini_service", return_value=mock_gemini):
-                with patch("graph.nodes.search.get_tavily_service", return_value=mock_tavily):
-                    final_state = await workflow.ainvoke(initial_state)
+    final_state = await workflow.ainvoke(initial_state)
 
     # 1. Title 생성 확인
     assert final_state["title"].startswith("Topic:")
@@ -80,7 +70,6 @@ async def test_factcheck_workflow():
     assert len(sentences) > 0
 
     # 3. 문장 처리 결과 확인 (SubGraph & Loop)
-    sentences = final_state["sentences"]
     # Reducer(add) 특성상 처리 전 문장과 처리 후 문장이 공존할 수 있음.
     # 따라서 "verdict" 키가 존재하는(=처리 완료된) Claim만 필터링해야 함.
     processed_claims = [s for s in sentences if s.get("type") == "claim" and "verdict" in s]

--- a/tests/graph/workflow_spec.py
+++ b/tests/graph/workflow_spec.py
@@ -4,7 +4,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from graph.nodes import extraction, search
+from graph.nodes import extraction, search, verification
 from graph.state import FactCheckState
 from graph.workflow import create_graph
 
@@ -47,6 +47,16 @@ async def test_factcheck_workflow():
         {"title": "AI News", "url": "https://trusted.com/ai", "snippet": "AI impact..."}
     ]
 
+    # verify_claim mock - 첫 호출은 FALSE, 이후는 TRUE (retry loop 테스트)
+    verify_call_count = 0
+
+    async def mock_verify_claim(self, claim, sources):
+        nonlocal verify_call_count
+        verify_call_count += 1
+        if verify_call_count == 1:
+            return {"verdict": "FALSE", "suggestion": "Need more evidence."}
+        return {"verdict": "TRUE"}
+
     with patch.dict("os.environ", {"GEMINI_API_KEY": "test-key", "TAVILY_API_KEY": "test-key"}):
         with patch.object(
             extraction.GeminiService,
@@ -58,7 +68,12 @@ async def test_factcheck_workflow():
                 "search",
                 new=AsyncMock(return_value=mock_search_result),
             ):
-                final_state = await workflow.ainvoke(initial_state)
+                with patch.object(
+                    verification.GeminiService,
+                    "verify_claim",
+                    new=mock_verify_claim,
+                ):
+                    final_state = await workflow.ainvoke(initial_state)
 
     # 1. Title 생성 확인
     assert final_state["title"].startswith("Topic:")


### PR DESCRIPTION
## 🎫 관련 이슈 (Related Issue)
- Closes #9 
- Closes #10 

## 🛠️ 작업 내용 (Description)
- **AS-IS**
  - search_node: Mock 구현으로 실제 검색 미수행
  - verification_node: stub으로 verdict 항상 "TRUE" 반환
  - 도메인 필터링(whitelist/blacklist) 미적용
  - `GeminiService.verify_claim()` 미구현

- **TO-BE**
  - search_node: TavilyService를 통한 실제 웹 검색 수행
    - whitelist/blacklist 도메인 필터 지원
    - 각 claim당 최대 5개 sources 반환
    - retry_count 로직으로 재검색 지원
  - verification_node: GeminiService를 통한 실제 사실 검증
    - sources 기반 TRUE/FALSE 판정
    - FALSE 시 한국어 수정 제안(suggestion) 제공
  - 프롬프트 분리: `VERIFICATION_PROMPT`를 prompts.py로 이동

## ✅ 체크리스트 (Self Checklist)

**기본 확인**
- [x] 내 코드를 스스로 리뷰했나요? (오타, 불필요한 주석 제거)
- [x] 로컬에서 빌드 및 테스트가 통과했나요?

**안정성 및 배포**
- [x] 환경변수(.env) 변경 사항이 있다면 공유했나요?
- [x] 민감한 정보(API Key 등)가 코드에 포함되지 않았나요?

## 🧪 테스트 방법 (How to Test)
1. 환경변수 설정: `.env`에 `TAVILY_API_KEY`와 `GEMINI_API_KEY` 추가
2. 단위 테스트 실행: `poetry run pytest src/services/ tests/graph/ -v`
3. Search E2E 테스트: `PYTHONPATH=src poetry run python scripts/test_search_e2e.py`
4. Verification E2E 테스트: `PYTHONPATH=src poetry run python scripts/test_verification_e2e.py`

## ⚠️ 특이사항 (Notes)
- `VERIFICATION_PROMPT`가 prompts.py로 분리되어 프롬프트 관리 일원화
- E2E 테스트 스크립트(`scripts/`)는 실제 API 호출을 수행하므로 API 키 필요