### PR TITLE
feat: MCP 핸들러와 파이프라인 연동 (#12)

### DIFF
--- a/scripts/test_extraction_e2e.py
+++ b/scripts/test_extraction_e2e.py
@@ -46,8 +46,8 @@ async def test():
     for s in result["sentences"]:
         type_str = s["type"]
         text_str = s["text"]
-        start = s["startIndex"]
-        end = s["endIndex"]
+        start = s["start_index"]
+        end = s["end_index"]
 
         # -1 인덱스 처리: LLM이 원본에서 문장을 찾지 못한 경우
         if start == -1:

--- a/scripts/test_pipeline_e2e.py
+++ b/scripts/test_pipeline_e2e.py
@@ -63,7 +63,14 @@ async def test():
 
     verified_claim_count = 0
 
-    for i, sentence in enumerate(sentences):
+    # 최종 결과만 필터링: opinion + verdict가 있는 claim
+    final_sentences = [
+        s for s in sentences
+        if s.get("type") == "opinion"
+        or (s.get("type") == "claim" and s.get("verdict") is not None)
+    ]
+
+    for i, sentence in enumerate(final_sentences):
         print(f"\n--- 문장 {i + 1} ---")
 
         sentence_type = sentence.get("type")
@@ -76,9 +83,6 @@ async def test():
 
         if sentence_type == "claim":
             verdict = sentence.get("verdict")
-            if verdict is None:
-                print("(extraction 단계 claim - 검증 스킵)")
-                continue
 
             assert verdict in ["TRUE", "FALSE"], \
                 f"잘못된 verdict: {verdict}"

--- a/scripts/test_pipeline_e2e.py
+++ b/scripts/test_pipeline_e2e.py
@@ -1,0 +1,110 @@
+"""E2E test for full factcheck pipeline with real APIs
+
+사용법: PYTHONPATH=src poetry run python scripts/test_pipeline_e2e.py
+"""
+
+from dotenv import load_dotenv
+
+_ = load_dotenv()
+
+import asyncio  # noqa: E402
+
+from graph.state import PipelineSentence  # noqa: E402
+from graph.workflow import create_graph  # noqa: E402
+
+
+async def test():
+    """E2E 테스트: 전체 파이프라인 실행 및 응답 구조 검증"""
+
+    # 1. 테스트 입력
+    test_text = (
+        "대한민국의 수도는 서울이다. "
+        "서울의 인구는 약 1000만 명이다. "
+        "한강은 서울을 가로지르는 강이다. "
+        "서울은 정말 살기 좋은 도시라고 생각한다. "
+        "지구는 태양계에서 세 번째 행성이다. "
+        "아인슈타인은 상대성 이론을 발표했다. "
+        "커피는 세상에서 가장 맛있는 음료이다."
+    )
+    print(f"입력: {test_text}\n")
+
+    # 2. 파이프라인 실행
+    print("파이프라인 실행 중...")
+    graph = create_graph()
+    result = await graph.ainvoke({
+        "original_text": test_text,
+        "whitelist": [],
+        "blacklist": [],
+        "title": "",
+        "sentences": [],
+    })
+
+    # 3. 구조 검증 (assertion) - LangGraph State는 snake_case
+    assert "title" in result, "title 필드 누락"
+    assert "original_text" in result, "original_text 필드 누락"
+    assert "sentences" in result, "sentences 필드 누락"
+    assert len(result["sentences"]) >= 1, "최소 1개 문장 필요"
+
+    # 4. 기본 정보 출력
+    # LangGraph ainvoke 반환 타입이 dict[str, Any]이므로 명시적 타입 변환
+    title: str = result["title"]
+    original_text: str = result["original_text"]
+    sentences: list[PipelineSentence] = result["sentences"]
+
+    print(f"✓ 제목: {title}")
+    print(f"✓ 원문: {original_text}")
+    print(f"✓ 문장 수: {len(sentences)}")
+
+    # 5. 각 문장 검증 + 출력
+    # Note: 현재 LangGraph add Reducer로 인해 sentences에
+    # extraction 단계(verdict 없음) + processing 단계(verdict 있음) claim이 공존할 수 있음.
+    # 향후 리팩토링 시 processing 결과만 남도록 개선 예정.
+    # 이 테스트는 두 경우 모두 통과하도록 작성됨.
+
+    verified_claim_count = 0
+
+    for i, sentence in enumerate(sentences):
+        print(f"\n--- 문장 {i + 1} ---")
+
+        sentence_type = sentence.get("type")
+        sentence_text = sentence.get("text")
+
+        assert sentence_type in ["claim", "opinion", "excluded"], \
+            f"잘못된 타입: {sentence_type}"
+        print(f"타입: {sentence_type}")
+        print(f"텍스트: {sentence_text}")
+
+        if sentence_type == "claim":
+            verdict = sentence.get("verdict")
+            if verdict is None:
+                print("(extraction 단계 claim - 검증 스킵)")
+                continue
+
+            assert verdict in ["TRUE", "FALSE"], \
+                f"잘못된 verdict: {verdict}"
+            assert "sources" in sentence, "sources 필드 누락"
+
+            sources = sentence.get("sources", [])
+            suggestion = sentence.get("suggestion")
+
+            print(f"판정: {verdict}")
+            print(f"출처 수: {len(sources)}")
+            if suggestion:
+                print(f"수정제안: {suggestion}")
+
+            verified_claim_count += 1
+
+        elif sentence_type == "opinion":
+            reason = sentence.get("reason")
+            assert reason is not None, "reason 필드 누락"
+            print(f"이유: {reason}")
+
+    assert verified_claim_count >= 1, \
+        f"검증된 claim이 없음 (verified_claim_count={verified_claim_count})"
+
+    print(f"\n✓ 검증된 claim 수: {verified_claim_count}")
+    print("\n✅ E2E 테스트 통과!")
+
+
+if __name__ == "__main__":
+    asyncio.run(test())

--- a/scripts/test_search_e2e.py
+++ b/scripts/test_search_e2e.py
@@ -18,8 +18,8 @@ async def test():
         {
             "type": "claim",
             "text": "비트코인은 2009년 사토시 나카모토에 의해 만들어졌습니다.",
-            "startIndex": 0,
-            "endIndex": 30,
+            "start_index": 0,
+            "end_index": 30,
             "retry_count": 0,
             "whitelist": [],
             "blacklist": [],
@@ -27,8 +27,8 @@ async def test():
         {
             "type": "claim",
             "text": "삼성전자는 1969년에 설립되었습니다.",
-            "startIndex": 31,
-            "endIndex": 50,
+            "start_index": 31,
+            "end_index": 50,
             "retry_count": 0,
             "whitelist": ["samsung.com"],  # whitelist 테스트
             "blacklist": ["wikipedia.org"],  # blacklist 테스트
@@ -36,8 +36,8 @@ async def test():
         {
             "type": "claim",
             "text": "한국의 GDP는 세계 13위입니다.",
-            "startIndex": 51,
-            "endIndex": 70,
+            "start_index": 51,
+            "end_index": 70,
             "retry_count": 0,
             "whitelist": [],
             "blacklist": [],

--- a/scripts/test_verification_e2e.py
+++ b/scripts/test_verification_e2e.py
@@ -18,8 +18,8 @@ async def test():
         {
             "type": "claim",
             "text": "비트코인은 2009년에 출시되었다.",
-            "startIndex": 0,
-            "endIndex": 20,
+            "start_index": 0,
+            "end_index": 20,
             "retry_count": 0,
             "sources": [
                 {
@@ -37,8 +37,8 @@ async def test():
         {
             "type": "claim",
             "text": "비트코인은 2008년에 출시되었다.",  # FALSE expected
-            "startIndex": 21,
-            "endIndex": 40,
+            "start_index": 21,
+            "end_index": 40,
             "retry_count": 0,
             "sources": [
                 {
@@ -51,8 +51,8 @@ async def test():
         {
             "type": "claim",
             "text": "삼성전자는 1969년에 설립되었습니다.",
-            "startIndex": 41,
-            "endIndex": 60,
+            "start_index": 41,
+            "end_index": 60,
             "retry_count": 0,
             "sources": [
                 {

--- a/src/graph/state.py
+++ b/src/graph/state.py
@@ -19,8 +19,8 @@ class PipelineSentence(TypedDict, total=False):
     # ===== 공통 (Extraction에서 채움) =====
     type: Literal["claim", "opinion", "excluded"]
     text: str
-    startIndex: int
-    endIndex: int
+    start_index: int
+    end_index: int
     retry_count: int  # 재검색 횟수 (기본값 0)
 
     # ===== 검색 필터 (workflow에서 전달) =====

--- a/src/graph/workflow.py
+++ b/src/graph/workflow.py
@@ -66,8 +66,6 @@ def create_processing_subgraph():
 
     return workflow.compile()
 
-    return workflow.compile()
-
 
 async def processing_node(sentence: PipelineSentence):
     """

--- a/src/main.py
+++ b/src/main.py
@@ -84,7 +84,7 @@ async def mcp_endpoint(request: Request) -> JSONResponse:
         )
         return JSONResponse(content=error_response.model_dump())
 
-    result, error = route_request(rpc_request.method, rpc_request.params)
+    result, error = await route_request(rpc_request.method, rpc_request.params)
 
     if error:
         code, message = error

--- a/src/mcp/handlers.py
+++ b/src/mcp/handlers.py
@@ -20,6 +20,8 @@ McpError = tuple[int, str]  # (code, message)
 # LangGraph 시스템 경계 타입 검증용
 FactCheckStateAdapter = TypeAdapter(FactCheckState)
 
+_graph = create_graph()
+
 FACTCHECK_TOOL = ToolDefinition(
     name="factcheck",
     description=(
@@ -83,8 +85,6 @@ async def handle_tools_call(
         )
 
     try:
-        graph = create_graph()
-
         initial_state: FactCheckState = {
             "original_text": args.text,
             "whitelist": args.whitelist,
@@ -93,7 +93,7 @@ async def handle_tools_call(
             "sentences": [],
         }
 
-        raw_state = await graph.ainvoke(initial_state)
+        raw_state = await _graph.ainvoke(initial_state)
         final_state = FactCheckStateAdapter.validate_python(raw_state)
 
         mcp_response = transform_pipeline_result(final_state)

--- a/src/mcp/handlers.py
+++ b/src/mcp/handlers.py
@@ -1,7 +1,9 @@
 """MCP 프로토콜 핸들러 (SRP: 도구 정의 및 핸들링만 담당)"""
 
-from pydantic import ValidationError
+from pydantic import TypeAdapter, ValidationError
 
+from graph.state import FactCheckState
+from graph.workflow import create_graph
 from mcp.errors import JsonRpcErrorCode
 from mcp.schemas.mcp import (
     ContentItem,
@@ -11,8 +13,12 @@ from mcp.schemas.mcp import (
     ToolsListResult,
 )
 from mcp.schemas.tools.factcheck import FactcheckArguments
+from mcp.transformers import result_to_json_content, transform_pipeline_result
 
 McpError = tuple[int, str]  # (code, message)
+
+# LangGraph 시스템 경계 타입 검증용
+FactCheckStateAdapter = TypeAdapter(FactCheckState)
 
 FACTCHECK_TOOL = ToolDefinition(
     name="factcheck",
@@ -51,7 +57,7 @@ def handle_tools_list() -> ToolsListResult:
     return ToolsListResult(tools=[FACTCHECK_TOOL])
 
 
-def handle_tools_call(
+async def handle_tools_call(
     params: ToolCallParams,
 ) -> tuple[ToolsCallResult | None, McpError | None]:
     """tools/call 요청 처리 - 도구 실행 및 결과 반환
@@ -76,11 +82,27 @@ def handle_tools_call(
             "Required: text (string). Optional: whitelist, blacklist (array of domains)",
         )
 
-    # TODO(MCP-03): 실제 파이프라인 구현 - 현재는 Mock 결과 반환
-    mock_result = (
-        f"[Mock] 팩트체크 요청 수신: '{args.text[:50]}...'"
-        if len(args.text) > 50
-        else f"[Mock] 팩트체크 요청 수신: '{args.text}'"
-    )
+    try:
+        graph = create_graph()
 
-    return ToolsCallResult(content=[ContentItem(type="text", text=mock_result)]), None
+        initial_state: FactCheckState = {
+            "original_text": args.text,
+            "whitelist": args.whitelist,
+            "blacklist": args.blacklist,
+            "title": "",
+            "sentences": [],
+        }
+
+        raw_state = await graph.ainvoke(initial_state)
+        final_state = FactCheckStateAdapter.validate_python(raw_state)
+
+        mcp_response = transform_pipeline_result(final_state)
+        json_content = result_to_json_content(mcp_response)
+
+        return ToolsCallResult(content=[ContentItem(type="text", text=json_content)]), None
+
+    except Exception as e:
+        return None, (
+            JsonRpcErrorCode.INTERNAL_ERROR,
+            f"Factcheck pipeline failed: {e!s}",
+        )

--- a/src/mcp/router.py
+++ b/src/mcp/router.py
@@ -10,7 +10,7 @@ McpResult = ToolsListResult | ToolsCallResult
 McpError = tuple[int, str]  # (code, message)
 
 
-def route_request(
+async def route_request(
     method: str,
     params: dict[str, JsonValue] | None,
 ) -> tuple[McpResult | None, McpError | None]:
@@ -41,7 +41,7 @@ def route_request(
                 "Invalid tools/call params. Required: name (string), arguments (object)",
             )
 
-        return handle_tools_call(call_params)
+        return await handle_tools_call(call_params)
 
     return None, (
         JsonRpcErrorCode.METHOD_NOT_FOUND,

--- a/src/mcp/schemas/__init__.py
+++ b/src/mcp/schemas/__init__.py
@@ -17,18 +17,31 @@ from mcp.schemas.mcp import (
     ToolsCallResult,
     ToolsListResult,
 )
-from mcp.schemas.tools import FactcheckArguments
+from mcp.schemas.tools import (
+    ClaimSentence,
+    FactcheckArguments,
+    FactcheckResult,
+    OpinionSentence,
+    ResultSentence,
+)
 
 __all__ = [
+    # JSON-RPC
     "JsonRpcRequest",
     "JsonRpcError",
     "JsonRpcSuccessResponse",
     "JsonRpcErrorResponse",
     "JsonRpcResponse",
+    # MCP Protocol
     "ToolDefinition",
     "ToolsListResult",
     "ToolCallParams",
     "ContentItem",
     "ToolsCallResult",
+    # Factcheck Tool
     "FactcheckArguments",
+    "FactcheckResult",
+    "ClaimSentence",
+    "OpinionSentence",
+    "ResultSentence",
 ]

--- a/src/mcp/schemas/tools/__init__.py
+++ b/src/mcp/schemas/tools/__init__.py
@@ -1,5 +1,17 @@
 """도구별 스키마 패키지"""
 
-from mcp.schemas.tools.factcheck import FactcheckArguments
+from mcp.schemas.tools.factcheck import (
+    ClaimSentence,
+    FactcheckArguments,
+    FactcheckResult,
+    OpinionSentence,
+    ResultSentence,
+)
 
-__all__ = ["FactcheckArguments"]
+__all__ = [
+    "FactcheckArguments",
+    "FactcheckResult",
+    "ClaimSentence",
+    "OpinionSentence",
+    "ResultSentence",
+]

--- a/src/mcp/schemas/tools/factcheck.py
+++ b/src/mcp/schemas/tools/factcheck.py
@@ -1,6 +1,14 @@
-"""Factcheck 도구 스키마"""
+"""Factcheck 도구 스키마 (Input/Output)"""
+
+from typing import Literal, TypedDict
 
 from pydantic import BaseModel
+
+from graph.state import Source
+
+# ============================================================
+# Input (요청)
+# ============================================================
 
 
 class FactcheckArguments(BaseModel):
@@ -9,3 +17,45 @@ class FactcheckArguments(BaseModel):
     text: str
     whitelist: list[str] = []
     blacklist: list[str] = []
+
+
+# ============================================================
+# Output (결과)
+# ============================================================
+
+
+class ClaimSentence(TypedDict):
+    """검증 대상 문장 (claim)"""
+
+    type: Literal["claim"]
+    text: str
+    startIndex: int
+    endIndex: int
+    verdict: Literal["TRUE", "FALSE"]
+    sources: list[Source]
+    suggestion: str | None
+
+
+class OpinionSentence(TypedDict):
+    """의견 문장 (opinion)"""
+
+    type: Literal["opinion"]
+    text: str
+    startIndex: int
+    endIndex: int
+    reason: str
+
+
+ResultSentence = ClaimSentence | OpinionSentence
+
+
+class FactcheckResult(TypedDict):
+    """팩트체크 결과 페이로드
+
+    tools/call 응답의 content[].text에 JSON으로 직렬화되어 담기는 구조.
+    NestJS 백엔드와의 계약(Contract).
+    """
+
+    title: str
+    originalText: str
+    sentences: list[ResultSentence]

--- a/src/mcp/transformers.py
+++ b/src/mcp/transformers.py
@@ -23,8 +23,8 @@ def transform_claim(sentence: PipelineSentence) -> ClaimSentence:
     return {
         "type": "claim",
         "text": sentence.get("text", ""),
-        "startIndex": sentence.get("startIndex", -1),
-        "endIndex": sentence.get("endIndex", -1),
+        "startIndex": sentence.get("start_index", -1),
+        "endIndex": sentence.get("end_index", -1),
         "verdict": sentence.get("verdict", "FALSE"),
         "sources": sentence.get("sources", []),
         "suggestion": sentence.get("suggestion"),
@@ -36,8 +36,8 @@ def transform_opinion(sentence: PipelineSentence) -> OpinionSentence:
     return {
         "type": "opinion",
         "text": sentence.get("text", ""),
-        "startIndex": sentence.get("startIndex", -1),
-        "endIndex": sentence.get("endIndex", -1),
+        "startIndex": sentence.get("start_index", -1),
+        "endIndex": sentence.get("end_index", -1),
         "reason": sentence.get("reason", ""),
     }
 

--- a/src/mcp/transformers.py
+++ b/src/mcp/transformers.py
@@ -1,0 +1,84 @@
+"""
+Pipeline 결과 → MCP 응답 변환기
+
+책임: 파이프라인 내부 데이터를 외부 API 형식으로 변환
+- 내부 필드 제거 (retry_count, whitelist, blacklist)
+- excluded 타입 문장 제외
+- JSON 직렬화
+"""
+
+import json
+
+from graph.state import FactCheckState, PipelineSentence
+from mcp.schemas.tools.factcheck import (
+    ClaimSentence,
+    FactcheckResult,
+    OpinionSentence,
+    ResultSentence,
+)
+
+
+def transform_claim(sentence: PipelineSentence) -> ClaimSentence:
+    """claim 문장을 MCP 응답 형식으로 변환."""
+    return {
+        "type": "claim",
+        "text": sentence.get("text", ""),
+        "startIndex": sentence.get("startIndex", -1),
+        "endIndex": sentence.get("endIndex", -1),
+        "verdict": sentence.get("verdict", "FALSE"),
+        "sources": sentence.get("sources", []),
+        "suggestion": sentence.get("suggestion"),
+    }
+
+
+def transform_opinion(sentence: PipelineSentence) -> OpinionSentence:
+    """opinion 문장을 MCP 응답 형식으로 변환."""
+    return {
+        "type": "opinion",
+        "text": sentence.get("text", ""),
+        "startIndex": sentence.get("startIndex", -1),
+        "endIndex": sentence.get("endIndex", -1),
+        "reason": sentence.get("reason", ""),
+    }
+
+
+def transform_pipeline_result(state: FactCheckState) -> FactcheckResult:
+    """
+    파이프라인 결과(FactCheckState)를 FactcheckResult로 변환.
+
+    변환 규칙:
+    1. 내부 필드 제거: retry_count, whitelist, blacklist
+    2. excluded 타입 문장 제외 (claim, opinion만 포함)
+    3. claim은 verdict가 있는 경우만 포함 (처리 완료된 것만)
+    """
+    result_sentences: list[ResultSentence] = []
+
+    for sentence in state["sentences"]:
+        sentence_type = sentence.get("type")
+
+        if sentence_type == "claim" and "verdict" in sentence:
+            result_sentences.append(transform_claim(sentence))
+        elif sentence_type == "opinion":
+            result_sentences.append(transform_opinion(sentence))
+        # excluded 타입은 무시 (API 응답에 포함하지 않음)
+
+    return {
+        "title": state["title"],
+        "originalText": state["original_text"],
+        "sentences": result_sentences,
+    }
+
+
+def result_to_json_content(result: FactcheckResult) -> str:
+    """
+    FactcheckResult를 JSON 문자열로 직렬화.
+
+    MCP 프로토콜에서 result.content[].text에 들어갈 문자열 생성.
+
+    Args:
+        result: 변환된 팩트체크 결과
+
+    Returns:
+        JSON 문자열 (한글 유지: ensure_ascii=False)
+    """
+    return json.dumps(result, ensure_ascii=False)

--- a/src/services/llm.py
+++ b/src/services/llm.py
@@ -52,7 +52,7 @@ class GeminiService:
 
         Returns:
             {"title": str, "sentences": list[dict]}
-            각 sentence는 type, text, startIndex, endIndex, reason?(opinion/excluded) 포함
+            각 sentence는 type, text, start_index, end_index, reason?(opinion/excluded) 포함
         """
         prompt = EXTRACTION_PROMPT.format(text=text)
 
@@ -78,13 +78,13 @@ class GeminiService:
             # 원본 텍스트에서 문장 위치 찾기
             idx = text.find(s.text, search_start)
             if idx != -1:
-                sentence_dict["startIndex"] = idx
-                sentence_dict["endIndex"] = idx + len(s.text)
+                sentence_dict["start_index"] = idx
+                sentence_dict["end_index"] = idx + len(s.text)
                 search_start = idx + len(s.text)  # 다음 검색 시작점
             else:
                 # 찾지 못한 경우 -1로 표시
-                sentence_dict["startIndex"] = -1
-                sentence_dict["endIndex"] = -1
+                sentence_dict["start_index"] = -1
+                sentence_dict["end_index"] = -1
 
             sentences_with_indices.append(sentence_dict)
 

--- a/src/services/llm_spec.py
+++ b/src/services/llm_spec.py
@@ -14,7 +14,7 @@ async def test_gemini_service_extract_sentences(mocker):
     mock_response = {
         "title": "테스트 제목",
         "sentences": [
-            {"type": "claim", "text": "테스트 문장입니다.", "startIndex": 0, "endIndex": 10}
+            {"type": "claim", "text": "테스트 문장입니다.", "start_index": 0, "end_index": 10}
         ],
     }
 
@@ -130,10 +130,10 @@ async def test_extract_sentences_index_calculation(mocker):
     result = await service.extract_sentences(original_text)
 
     # 검증 - 인덱스가 정확히 계산되었는지
-    assert result["sentences"][0]["startIndex"] == 0
-    assert result["sentences"][0]["endIndex"] == 11  # "첫 번째 문장입니다." 길이
-    assert result["sentences"][1]["startIndex"] == 12  # 공백 포함
-    assert result["sentences"][1]["endIndex"] == 23  # "두 번째 문장입니다." 끝
+    assert result["sentences"][0]["start_index"] == 0
+    assert result["sentences"][0]["end_index"] == 11  # "첫 번째 문장입니다." 길이
+    assert result["sentences"][1]["start_index"] == 12  # 공백 포함
+    assert result["sentences"][1]["end_index"] == 23  # "두 번째 문장입니다." 끝
 
 
 @pytest.mark.asyncio
@@ -163,10 +163,10 @@ async def test_extract_sentences_duplicate_handling(mocker):
     result = await service.extract_sentences(original_text)
 
     # 검증 - 첫 번째 "안녕하세요"와 두 번째 "안녕하세요"의 인덱스가 다름
-    assert result["sentences"][0]["startIndex"] == 0  # 첫 번째 "안녕하세요."
-    assert result["sentences"][0]["endIndex"] == 6
-    assert result["sentences"][2]["startIndex"] == 14  # 두 번째 "안녕하세요."
-    assert result["sentences"][2]["endIndex"] == 20
+    assert result["sentences"][0]["start_index"] == 0  # 첫 번째 "안녕하세요."
+    assert result["sentences"][0]["end_index"] == 6
+    assert result["sentences"][2]["start_index"] == 14  # 두 번째 "안녕하세요."
+    assert result["sentences"][2]["end_index"] == 20
 
 
 @pytest.mark.asyncio
@@ -194,8 +194,8 @@ async def test_extract_sentences_not_found_in_text(mocker):
     result = await service.extract_sentences(original_text)
 
     # 검증 - 찾지 못한 경우 -1
-    assert result["sentences"][0]["startIndex"] == -1
-    assert result["sentences"][0]["endIndex"] == -1
+    assert result["sentences"][0]["start_index"] == -1
+    assert result["sentences"][0]["end_index"] == -1
 
 
 @pytest.mark.asyncio

--- a/tests/graph/nodes_spec.py
+++ b/tests/graph/nodes_spec.py
@@ -22,7 +22,7 @@ async def test_extraction_node(mock_gemini_service):
     mock_result = {
         "title": "테스트 제목",
         "sentences": [
-            {"type": "claim", "text": "테스트 문장입니다.", "startIndex": 0, "endIndex": 10}
+            {"type": "claim", "text": "테스트 문장입니다.", "start_index": 0, "end_index": 10}
         ],
     }
 
@@ -34,7 +34,7 @@ async def test_extraction_node(mock_gemini_service):
     first_sent = new_state["sentences"][0]
     assert "type" in first_sent
     assert "text" in first_sent
-    assert "startIndex" in first_sent
+    assert "start_index" in first_sent
 
 
 @pytest.mark.asyncio
@@ -43,8 +43,8 @@ async def test_search_node(mock_tavily_service):
     sentence: PipelineSentence = {
         "type": "claim",
         "text": "테스트 주장",
-        "startIndex": 0,
-        "endIndex": 5,
+        "start_index": 0,
+        "end_index": 5,
         "retry_count": 0,
     }
 
@@ -64,8 +64,8 @@ async def test_search_node_retry(mock_tavily_service):
     sentence: PipelineSentence = {
         "type": "claim",
         "text": "테스트 주장",
-        "startIndex": 0,
-        "endIndex": 5,
+        "start_index": 0,
+        "end_index": 5,
         "retry_count": 0,
         "sources": [{"title": "Old", "url": "url", "snippet": "old"}],
     }
@@ -85,8 +85,8 @@ async def test_search_node_with_domain_filters(mock_tavily_service):
     sentence: PipelineSentence = {
         "type": "claim",
         "text": "테스트 주장",
-        "startIndex": 0,
-        "endIndex": 5,
+        "start_index": 0,
+        "end_index": 5,
         "retry_count": 0,
         "whitelist": ["trusted.com", "reliable.org"],
         "blacklist": ["spam.com"],
@@ -113,8 +113,8 @@ async def test_verification_node_true(mock_gemini_service):
     sentence: PipelineSentence = {
         "type": "claim",
         "text": "테스트 주장",
-        "startIndex": 0,
-        "endIndex": 5,
+        "start_index": 0,
+        "end_index": 5,
         "sources": [{"title": "T", "url": "U", "snippet": "S"}],
         "retry_count": 0,
     }
@@ -134,8 +134,8 @@ async def test_verification_node_false_with_suggestion(mock_gemini_service):
     sentence: PipelineSentence = {
         "type": "claim",
         "text": "비트코인은 2008년에 출시되었다.",
-        "startIndex": 0,
-        "endIndex": 20,
+        "start_index": 0,
+        "end_index": 20,
         "sources": [{"title": "Bitcoin Wiki", "url": "https://...", "snippet": "2009년 출시..."}],
         "retry_count": 0,
     }

--- a/tests/graph/workflow_spec.py
+++ b/tests/graph/workflow_spec.py
@@ -28,14 +28,14 @@ async def test_factcheck_workflow(mock_gemini_service, mock_tavily_service):
             {
                 "type": "claim",
                 "text": "AI is changing the world.",
-                "startIndex": 0,
-                "endIndex": 25,
+                "start_index": 0,
+                "end_index": 25,
             },
             {
                 "type": "opinion",
                 "text": "It is good.",
-                "startIndex": 26,
-                "endIndex": 37,
+                "start_index": 26,
+                "end_index": 37,
                 "reason": "Subjective judgment",
             },
         ],

--- a/tests/integration/mcp_endpoint_spec.py
+++ b/tests/integration/mcp_endpoint_spec.py
@@ -1,5 +1,8 @@
 """MCP 프로토콜 통합 테스트 (Outside-In TDD)"""
 
+import json
+from unittest.mock import AsyncMock
+
 import pytest
 from httpx import ASGITransport, AsyncClient
 
@@ -26,9 +29,35 @@ async def test_tools_list_returns_factcheck_tool():
 
 
 @pytest.mark.asyncio
-async def test_tools_call_returns_mock_result():
-    """tools/call 요청 시 팩트체크 결과 반환 (Mock)"""
-    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+async def test_tools_call_success_returns_factcheck_result(
+    mock_gemini_service, mock_tavily_service
+):
+    """tools/call 성공 시 파이프라인 실행 후 팩트체크 결과 반환"""
+    from unittest.mock import AsyncMock
+
+    # Mock 설정: Gemini extraction
+    mock_gemini_service.extract_sentences = AsyncMock(
+        return_value={
+            "title": "테스트 제목",
+            "sentences": [
+                {"type": "claim", "text": "테스트 문장", "startIndex": 0, "endIndex": 6}
+            ],
+        }
+    )
+
+    # Mock 설정: Tavily search
+    mock_tavily_service.search = AsyncMock(
+        return_value=[{"title": "출처", "url": "https://example.com", "snippet": "내용"}]
+    )
+
+    # Mock 설정: Gemini verification
+    mock_gemini_service.verify_claim = AsyncMock(
+        return_value={"verdict": "TRUE", "suggestion": None}
+    )
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
         response = await client.post(
             "/mcp",
             json={
@@ -39,12 +68,109 @@ async def test_tools_call_returns_mock_result():
             },
         )
 
+    # JSON-RPC 응답 구조 검증
     assert response.status_code == 200
     data = response.json()
     assert data["id"] == 2
-    assert "error" not in data  # 성공 응답에는 error 필드 없음
+    assert "error" not in data
     assert "content" in data["result"]
     assert data["result"]["content"][0]["type"] == "text"
+
+    # 파이프라인 응답 구조 검증
+    import json
+
+    content_text = data["result"]["content"][0]["text"]
+    result = json.loads(content_text)
+
+    assert result["title"] == "테스트 제목"
+    assert result["originalText"] == "테스트 문장"
+    assert len(result["sentences"]) == 1
+    assert result["sentences"][0]["type"] == "claim"
+    assert result["sentences"][0]["verdict"] == "TRUE"
+
+
+@pytest.mark.asyncio
+async def test_tools_call_pipeline_failure_returns_internal_error(
+    mock_gemini_service, mock_tavily_service
+):
+    """tools/call 파이프라인 실패 시 Internal Error 반환"""
+    from unittest.mock import AsyncMock
+
+    # Mock 설정: Gemini extraction 실패
+    mock_gemini_service.extract_sentences = AsyncMock(
+        side_effect=Exception("Gemini API timeout")
+    )
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        response = await client.post(
+            "/mcp",
+            json={
+                "jsonrpc": "2.0",
+                "id": 3,
+                "method": "tools/call",
+                "params": {"name": "factcheck", "arguments": {"text": "테스트"}},
+            },
+        )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["id"] == 3
+    assert "error" in data
+    assert data["error"]["code"] == -32603  # Internal Error
+
+
+@pytest.mark.asyncio
+async def test_tools_call_invalid_arguments_returns_error():
+    """tools/call 필수 인자 누락 시 Invalid Params 반환"""
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        response = await client.post(
+            "/mcp",
+            json={
+                "jsonrpc": "2.0",
+                "id": 4,
+                "method": "tools/call",
+                "params": {
+                    "name": "factcheck",
+                    "arguments": {},  # text 필드 누락
+                },
+            },
+        )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["id"] == 4
+    assert "error" in data
+    assert data["error"]["code"] == -32602  # Invalid Params
+
+
+@pytest.mark.asyncio
+async def test_tools_call_unknown_tool_returns_error():
+    """tools/call 알 수 없는 도구 요청 시 Invalid Params 반환"""
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        response = await client.post(
+            "/mcp",
+            json={
+                "jsonrpc": "2.0",
+                "id": 5,
+                "method": "tools/call",
+                "params": {
+                    "name": "unknown_tool",  # 존재하지 않는 도구
+                    "arguments": {"text": "테스트"},
+                },
+            },
+        )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["id"] == 5
+    assert "error" in data
+    assert data["error"]["code"] == -32602  # Invalid Params
 
 
 @pytest.mark.asyncio

--- a/tests/integration/mcp_endpoint_spec.py
+++ b/tests/integration/mcp_endpoint_spec.py
@@ -33,8 +33,6 @@ async def test_tools_call_success_returns_factcheck_result(
     mock_gemini_service, mock_tavily_service
 ):
     """tools/call 성공 시 파이프라인 실행 후 팩트체크 결과 반환"""
-    from unittest.mock import AsyncMock
-
     # Mock 설정: Gemini extraction
     mock_gemini_service.extract_sentences = AsyncMock(
         return_value={
@@ -77,8 +75,6 @@ async def test_tools_call_success_returns_factcheck_result(
     assert data["result"]["content"][0]["type"] == "text"
 
     # 파이프라인 응답 구조 검증
-    import json
-
     content_text = data["result"]["content"][0]["text"]
     result = json.loads(content_text)
 
@@ -94,8 +90,6 @@ async def test_tools_call_pipeline_failure_returns_internal_error(
     mock_gemini_service, mock_tavily_service
 ):
     """tools/call 파이프라인 실패 시 Internal Error 반환"""
-    from unittest.mock import AsyncMock
-
     # Mock 설정: Gemini extraction 실패
     mock_gemini_service.extract_sentences = AsyncMock(
         side_effect=Exception("Gemini API timeout")

--- a/tests/integration/mcp_endpoint_spec.py
+++ b/tests/integration/mcp_endpoint_spec.py
@@ -40,7 +40,7 @@ async def test_tools_call_success_returns_factcheck_result(
         return_value={
             "title": "테스트 제목",
             "sentences": [
-                {"type": "claim", "text": "테스트 문장", "startIndex": 0, "endIndex": 6}
+                {"type": "claim", "text": "테스트 문장", "start_index": 0, "end_index": 6}
             ],
         }
     )


### PR DESCRIPTION
## 관련 이슈 (Related Issue)
- Fixes #12

## 작업 내용 (Description)
- AS-IS: MCP 핸들러가 파이프라인과 연결되지 않음
- TO-BE: MCP tools/call 요청 시 LangGraph 파이프라인 실행

### 주요 변경사항
1. **MCP 핸들러-파이프라인 연동**
   - `tools/call` 요청 처리 시 `create_graph()` 호출
   - 파이프라인 결과를 MCP 응답 형식으로 변환하는 transformer 추가

2. **통합/E2E 테스트 추가**
   - MCP 엔드포인트 통합 테스트
   - 실제 API 호출 E2E 테스트

## 체크리스트 (Self Checklist)

**기본 확인**
- [x] 내 코드를 스스로 리뷰했나요?
- [x] 로컬에서 테스트가 통과했나요?

**안정성 및 배포**
- [x] 민감한 정보(API Key 등)가 코드에 포함되지 않았나요?

## 테스트 방법 (How to Test)
1. 단위/통합 테스트: `poetry run pytest`
2. E2E 테스트: `PYTHONPATH=src poetry run python scripts/test_pipeline_e2e.py`

## 특이사항 (Notes)
- 오전에 말씀드린 PipelineSentence의 startIndex와 endIndex를 스네이크 케이스인 start_index와 end_index로 변경하였습니다
- E2E 테스트는 실제 API 호출 (Gemini, Tavily)