### PR TITLE
feat: 전역 에러 핸들러 및 로깅 구현 (#14)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,7 @@
-# pydantic-settings 기반 필수 환경변수
+# [Required] 필수 환경변수
 GEMINI_API_KEY=""
 TAVILY_API_KEY=""
+
+# [Optional] 선택 환경변수 (주석 처리된 값은 기본값입니다)
+ENVIRONMENT="dev" # dev, prod
+GEMINI_MODEL="gemini-2.5-flash-lite"

--- a/poetry.lock
+++ b/poetry.lock
@@ -1658,6 +1658,18 @@ anyio = ">=3.6.2,<5"
 full = ["httpx (>=0.27.0,<0.29.0)", "itsdangerous", "jinja2", "python-multipart (>=0.0.18)", "pyyaml"]
 
 [[package]]
+name = "structlog"
+version = "25.5.0"
+description = "Structured Logging for Python"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "structlog-25.5.0-py3-none-any.whl", hash = "sha256:a8453e9b9e636ec59bd9e79bbd4a72f025981b3ba0f5837aebf48f02f37a7f9f"},
+    {file = "structlog-25.5.0.tar.gz", hash = "sha256:098522a3bebed9153d4570c6d0288abf80a031dfdb2048d59a49e9dc2190fc98"},
+]
+
+[[package]]
 name = "tavily-python"
 version = "0.7.17"
 description = "Python wrapper for the Tavily API"
@@ -2384,4 +2396,4 @@ cffi = ["cffi (>=1.17,<2.0) ; platform_python_implementation != \"PyPy\" and pyt
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.13,<4.0"
-content-hash = "081424497e0768bf51d3b8b7a16ae450787ec6011739855c65741f178c8ed8ed"
+content-hash = "aa4e3a278e6cd942e9314c3f7fa7109d5696fa0f0f499296de0590157b76420b"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,8 @@ dependencies = [
     "google-genai (>=1.56.0,<2.0.0)",
     "tavily-python (>=0.7.17,<0.8.0)",
     "pydantic (>=2.12.5,<3.0.0)",
-    "pydantic-settings (>=2.9.1,<3.0.0)"
+    "pydantic-settings (>=2.9.1,<3.0.0)",
+    "structlog (>=25.5.0,<26.0.0)"
 ]
 
 [tool.commitizen]

--- a/scripts/test_pipeline_e2e.py
+++ b/scripts/test_pipeline_e2e.py
@@ -31,13 +31,15 @@ async def test():
     # 2. 파이프라인 실행
     print("파이프라인 실행 중...")
     graph = create_graph()
-    result = await graph.ainvoke({
-        "original_text": test_text,
-        "whitelist": [],
-        "blacklist": [],
-        "title": "",
-        "sentences": [],
-    })
+    result = await graph.ainvoke(
+        {
+            "original_text": test_text,
+            "whitelist": [],
+            "blacklist": [],
+            "title": "",
+            "sentences": [],
+        }
+    )
 
     # 3. 구조 검증 (assertion) - LangGraph State는 snake_case
     assert "title" in result, "title 필드 누락"
@@ -65,9 +67,9 @@ async def test():
 
     # 최종 결과만 필터링: opinion + verdict가 있는 claim
     final_sentences = [
-        s for s in sentences
-        if s.get("type") == "opinion"
-        or (s.get("type") == "claim" and s.get("verdict") is not None)
+        s
+        for s in sentences
+        if s.get("type") == "opinion" or (s.get("type") == "claim" and s.get("verdict") is not None)
     ]
 
     for i, sentence in enumerate(final_sentences):
@@ -76,16 +78,14 @@ async def test():
         sentence_type = sentence.get("type")
         sentence_text = sentence.get("text")
 
-        assert sentence_type in ["claim", "opinion", "excluded"], \
-            f"잘못된 타입: {sentence_type}"
+        assert sentence_type in ["claim", "opinion", "excluded"], f"잘못된 타입: {sentence_type}"
         print(f"타입: {sentence_type}")
         print(f"텍스트: {sentence_text}")
 
         if sentence_type == "claim":
             verdict = sentence.get("verdict")
 
-            assert verdict in ["TRUE", "FALSE"], \
-                f"잘못된 verdict: {verdict}"
+            assert verdict in ["TRUE", "FALSE"], f"잘못된 verdict: {verdict}"
             assert "sources" in sentence, "sources 필드 누락"
 
             sources = sentence.get("sources", [])
@@ -103,8 +103,9 @@ async def test():
             assert reason is not None, "reason 필드 누락"
             print(f"이유: {reason}")
 
-    assert verified_claim_count >= 1, \
+    assert verified_claim_count >= 1, (
         f"검증된 claim이 없음 (verified_claim_count={verified_claim_count})"
+    )
 
     print(f"\n✓ 검증된 claim 수: {verified_claim_count}")
     print("\n✅ E2E 테스트 통과!")

--- a/src/common/logger.py
+++ b/src/common/logger.py
@@ -1,0 +1,58 @@
+import logging
+import sys
+from typing import Any
+
+import structlog
+from structlog.types import EventDict, Processor
+
+
+def configure_logger() -> None:
+    """Structlog 설정 초기화"""
+
+    shared_processors: list[Processor] = [
+        structlog.contextvars.merge_contextvars,
+        structlog.stdlib.add_logger_name,
+        structlog.stdlib.add_log_level,
+        structlog.stdlib.PositionalArgumentsFormatter(),
+        structlog.processors.TimeStamper(fmt="iso"),
+        structlog.processors.StackInfoRenderer(),
+        structlog.processors.format_exc_info,
+        structlog.processors.UnicodeDecoder(),
+    ]
+
+    structlog.configure(
+        processors=shared_processors
+        + [
+            structlog.stdlib.ProcessorFormatter.wrap_for_formatter,
+        ],
+        logger_factory=structlog.stdlib.LoggerFactory(),
+        wrapper_class=structlog.stdlib.BoundLogger,
+        cache_logger_on_first_use=True,
+    )
+
+    # 파이썬 표준 로깅 설정 (JSON 포맷터 연결)
+    formatter = structlog.stdlib.ProcessorFormatter(
+        foreign_pre_chain=shared_processors,
+        processors=[
+            _drop_color_message_key,
+            structlog.processors.JSONRenderer(),
+        ],
+    )
+
+    handler = logging.StreamHandler(sys.stdout)
+    handler.setFormatter(formatter)
+
+    root_logger = logging.getLogger()
+    root_logger.addHandler(handler)
+    root_logger.setLevel(logging.INFO)
+
+
+def _drop_color_message_key(_: Any, __: Any, event_dict: EventDict) -> EventDict:
+    """Uvicorn 등에서 넘어오는 color_message 키 제거 (JSON 로그 오염 방지)"""
+    event_dict.pop("color_message", None)
+    return event_dict
+
+
+def get_logger(name: str | None = None) -> structlog.stdlib.BoundLogger:
+    """로거 인스턴스 반환"""
+    return structlog.get_logger(name)

--- a/src/common/logger.py
+++ b/src/common/logger.py
@@ -1,9 +1,8 @@
 import logging
 import sys
-from typing import Any
 
 import structlog
-from structlog.types import EventDict, Processor
+from structlog.types import EventDict, Processor, WrappedLogger
 
 
 def configure_logger() -> None:
@@ -47,7 +46,11 @@ def configure_logger() -> None:
     root_logger.setLevel(logging.INFO)
 
 
-def _drop_color_message_key(_: Any, __: Any, event_dict: EventDict) -> EventDict:
+def _drop_color_message_key(
+    _logger: WrappedLogger,
+    _method_name: str,
+    event_dict: EventDict,
+) -> EventDict:
     """Uvicorn 등에서 넘어오는 color_message 키 제거 (JSON 로그 오염 방지)"""
     event_dict.pop("color_message", None)
     return event_dict

--- a/src/config.py
+++ b/src/config.py
@@ -1,6 +1,7 @@
 """환경변수 설정 관리 - pydantic-settings 기반"""
 
 from functools import lru_cache
+from typing import Literal
 
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
@@ -19,6 +20,8 @@ class Settings(BaseSettings):
     gemini_api_key: str
     tavily_api_key: str
     gemini_model: str = "gemini-2.5-flash-lite"
+
+    environment: Literal["dev", "prod"] = "dev"
 
 
 @lru_cache(maxsize=1)

--- a/src/main.py
+++ b/src/main.py
@@ -53,22 +53,26 @@ async def global_exception_handler(request: Request, exc: Exception) -> JSONResp
         body = await request.json()
         if isinstance(body, dict):
             request_id = body.get("id")
+    except Exception as e:
+        log.debug("Failed to parse request body for error context", error=str(e))
+
+    log.error("Unhandled exception occurred", json_rpc_id=request_id, exc_info=exc)
+
+    try:
+        is_dev = get_settings().environment == "dev"
     except Exception:
-        pass
+        is_dev = False
 
-    log.exception("Unhandled exception occurred", json_rpc_id=request_id)
-
-    error_data = ErrorData(
-        detail=str(exc),
-        type=type(exc).__name__,
-    )
-
-    settings = get_settings()
-    if settings.environment == "dev":
+    if is_dev:
         error_data = ErrorData(
             detail=str(exc),
             type=type(exc).__name__,
             traceback="".join(traceback.format_exception(type(exc), exc, exc.__traceback__)),
+        )
+    else:
+        error_data = ErrorData(
+            detail="An internal error occurred",
+            type=type(exc).__name__,
         )
 
     error_response = JsonRpcErrorResponse(

--- a/src/main.py
+++ b/src/main.py
@@ -1,12 +1,15 @@
+import traceback
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 from json import JSONDecodeError
+from typing import Any
 
 from dotenv import load_dotenv
 from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
 from pydantic import ValidationError
 
+from common.logger import configure_logger, get_logger
 from config import get_settings
 from mcp import (
     JsonRpcError,
@@ -19,6 +22,9 @@ from mcp.router import route_request
 
 _ = load_dotenv()
 
+configure_logger()
+log = get_logger(__name__)
+
 
 @asynccontextmanager
 async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
@@ -28,6 +34,42 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
 
 
 app = FastAPI(title="RT-Fact MCP Server", lifespan=lifespan)
+
+
+@app.exception_handler(Exception)
+async def global_exception_handler(request: Request, exc: Exception) -> JSONResponse:
+    """전역 예외 처리: 모든 Unhandled Exception을 규격화된 JSON-RPC 에러로 반환"""
+
+    request_id = None
+    try:
+        body = await request.json()
+        if isinstance(body, dict):
+            request_id = body.get("id")
+    except Exception:
+        pass
+
+    log.exception("Unhandled exception occurred", json_rpc_id=request_id)
+
+    error_data: dict[str, Any] = {
+        "detail": str(exc),
+        "type": type(exc).__name__,
+    }
+
+    settings = get_settings()
+    if settings.environment == "dev":
+        error_data["traceback"] = "".join(
+            traceback.format_exception(type(exc), exc, exc.__traceback__)
+        )
+
+    error_response = JsonRpcErrorResponse(
+        id=request_id,
+        error=JsonRpcError(
+            code=JsonRpcErrorCode.INTERNAL_ERROR,
+            message="Internal error",
+            data=error_data,
+        ),
+    )
+    return JSONResponse(content=error_response.model_dump())
 
 
 @app.get("/")

--- a/src/main.py
+++ b/src/main.py
@@ -2,12 +2,11 @@ import traceback
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 from json import JSONDecodeError
-from typing import Any
 
 from dotenv import load_dotenv
 from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
-from pydantic import ValidationError
+from pydantic import BaseModel, ValidationError
 
 from common.logger import configure_logger, get_logger
 from config import get_settings
@@ -19,6 +18,15 @@ from mcp import (
     JsonRpcSuccessResponse,
 )
 from mcp.router import route_request
+
+
+class ErrorData(BaseModel):
+    """전역 예외 처리 응답에 포함되는 에러 데이터"""
+
+    detail: str
+    type: str
+    traceback: str | None = None
+
 
 _ = load_dotenv()
 
@@ -50,15 +58,17 @@ async def global_exception_handler(request: Request, exc: Exception) -> JSONResp
 
     log.exception("Unhandled exception occurred", json_rpc_id=request_id)
 
-    error_data: dict[str, Any] = {
-        "detail": str(exc),
-        "type": type(exc).__name__,
-    }
+    error_data = ErrorData(
+        detail=str(exc),
+        type=type(exc).__name__,
+    )
 
     settings = get_settings()
     if settings.environment == "dev":
-        error_data["traceback"] = "".join(
-            traceback.format_exception(type(exc), exc, exc.__traceback__)
+        error_data = ErrorData(
+            detail=str(exc),
+            type=type(exc).__name__,
+            traceback="".join(traceback.format_exception(type(exc), exc, exc.__traceback__)),
         )
 
     error_response = JsonRpcErrorResponse(
@@ -66,7 +76,7 @@ async def global_exception_handler(request: Request, exc: Exception) -> JSONResp
         error=JsonRpcError(
             code=JsonRpcErrorCode.INTERNAL_ERROR,
             message="Internal error",
-            data=error_data,
+            data=error_data.model_dump(exclude_none=True),
         ),
     )
     return JSONResponse(content=error_response.model_dump())

--- a/src/mcp/handlers.py
+++ b/src/mcp/handlers.py
@@ -2,6 +2,7 @@
 
 from pydantic import TypeAdapter, ValidationError
 
+from common.logger import get_logger
 from graph.state import FactCheckState
 from graph.workflow import create_graph
 from mcp.errors import JsonRpcErrorCode
@@ -16,14 +17,17 @@ from mcp.schemas.tools.factcheck import FactcheckArguments
 from mcp.transformers import result_to_json_content, transform_pipeline_result
 
 McpError = tuple[int, str]  # (code, message)
+FACTCHECK_TOOL_NAME = "factcheck"
 
 # LangGraph 시스템 경계 타입 검증용
 FactCheckStateAdapter = TypeAdapter(FactCheckState)
 
+log = get_logger(__name__)
+
 _graph = create_graph()
 
 FACTCHECK_TOOL = ToolDefinition(
-    name="factcheck",
+    name=FACTCHECK_TOOL_NAME,
     description=(
         "텍스트의 사실 여부를 검증합니다. "
         "뉴스 기사, 주장, 통계 등 사실 확인이 필요한 텍스트에 사용하세요. "
@@ -56,6 +60,7 @@ FACTCHECK_TOOL = ToolDefinition(
 
 def handle_tools_list() -> ToolsListResult:
     """tools/list 요청 처리 - 사용 가능한 도구 목록 반환"""
+    log.info("tools/list called")
     return ToolsListResult(tools=[FACTCHECK_TOOL])
 
 
@@ -68,19 +73,23 @@ async def handle_tools_call(
         (result, None): 성공
         (None, (code, message)): 실패 (Actionable Error)
     """
-    if params.name != "factcheck":
+    if params.name != FACTCHECK_TOOL_NAME:
+        log.warning("Unknown tool requested", tool_name=params.name)
         return None, (
             JsonRpcErrorCode.INVALID_PARAMS,
-            f"Unknown tool '{params.name}'. Available: factcheck",
+            f"Unknown tool '{params.name}'. Available: {FACTCHECK_TOOL_NAME}",
         )
+
+    log.info("Tool execution started", tool_name=params.name)
 
     try:
         args = FactcheckArguments.model_validate(params.arguments)
     except ValidationError as e:
+        log.warning("Tool arguments validation failed", error=str(e), arguments=params.arguments)
         errors = "; ".join(f"{err['loc'][0]}: {err['msg']}" for err in e.errors())
         return None, (
             JsonRpcErrorCode.INVALID_PARAMS,
-            f"Invalid arguments for 'factcheck': {errors}. "
+            f"Invalid arguments for '{FACTCHECK_TOOL_NAME}': {errors}. "
             "Required: text (string). Optional: whitelist, blacklist (array of domains)",
         )
 
@@ -99,9 +108,11 @@ async def handle_tools_call(
         mcp_response = transform_pipeline_result(final_state)
         json_content = result_to_json_content(mcp_response)
 
+        log.info("Tool execution completed", tool_name=params.name)
         return ToolsCallResult(content=[ContentItem(type="text", text=json_content)]), None
 
     except Exception as e:
+        log.exception("Tool execution failed", tool_name=params.name, error=str(e))
         return None, (
             JsonRpcErrorCode.INTERNAL_ERROR,
             f"Factcheck pipeline failed: {e!s}",

--- a/tests/integration/global_exception_spec.py
+++ b/tests/integration/global_exception_spec.py
@@ -1,0 +1,92 @@
+import json
+
+import pytest
+from fastapi import Request
+from fastapi.testclient import TestClient
+
+from config import get_settings
+from main import app, global_exception_handler
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+def test_global_exception_handler_returns_json_rpc_error(client: TestClient):
+    """전역 예외 처리기가 JSON-RPC 규격의 에러를 반환하는지 테스트"""
+    # 유효하지 않은 JSON 전송 -> JSONDecodeError
+    response = client.post("/mcp", content="{invalid-json}")
+    assert response.status_code == 200  # JSON-RPC는 에러도 200 OK로 줍니다 (보통)
+    data = response.json()
+    assert data["error"]["code"] == -32700  # Parse Error
+
+
+@pytest.mark.asyncio
+async def test_handler_traceback_logic() -> None:
+    """핸들러 함수 단위 테스트: 환경변수에 따른 Traceback 포함 여부"""
+
+    # 1. Dev 환경 설정
+    settings = get_settings()
+    settings.environment = "dev"
+
+    # 가짜 요청 Scope 생성
+    scope = {
+        "type": "http",
+        "headers": [],
+        "router": None,
+        "endpoint": None,
+        "path_params": {},
+        "query_string": b"",
+        "server": ("testserver", 80),
+        "client": ("testclient", 50000),
+        "scheme": "http",
+        "root_path": "",
+        "app": app,
+    }
+    request = Request(scope)
+
+    # 예외 발생 및 핸들러 호출
+    try:
+        _ = 1 / 0
+    except ZeroDivisionError as exc:
+        response = await global_exception_handler(request, exc)
+        body = json.loads(bytes(response.body))
+
+        # 검증: traceback이 있어야 함
+        assert "traceback" in body["error"]["data"]
+        assert "ZeroDivisionError" in body["error"]["data"]["traceback"]
+
+
+@pytest.mark.asyncio
+async def test_handler_no_traceback_in_prod(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Prod 환경에서는 Traceback이 없어야 함"""
+
+    # 1. Prod 환경 설정
+    settings = get_settings()
+    monkeypatch.setattr(settings, "environment", "prod")
+
+    scope = {
+        "type": "http",
+        "headers": [],
+        "router": None,
+        "endpoint": None,
+        "path_params": {},
+        "query_string": b"",
+        "server": ("testserver", 80),
+        "client": ("testclient", 50000),
+        "scheme": "http",
+        "root_path": "",
+        "app": app,
+    }
+    request = Request(scope)
+
+    try:
+        raise ValueError("Critical Secret Error")
+    except ValueError as exc:
+        response = await global_exception_handler(request, exc)
+        body = json.loads(bytes(response.body))
+
+        # 검증: traceback이 없어야 함
+        assert "traceback" not in body["error"]["data"]
+        assert body["error"]["data"]["detail"] == "Critical Secret Error"

--- a/tests/integration/global_exception_spec.py
+++ b/tests/integration/global_exception_spec.py
@@ -89,4 +89,4 @@ async def test_handler_no_traceback_in_prod(monkeypatch: pytest.MonkeyPatch) -> 
 
         # 검증: traceback이 없어야 함
         assert "traceback" not in body["error"]["data"]
-        assert body["error"]["data"]["detail"] == "Critical Secret Error"
+        assert body["error"]["data"]["detail"] == "An internal error occurred"

--- a/tests/integration/mcp_endpoint_spec.py
+++ b/tests/integration/mcp_endpoint_spec.py
@@ -53,9 +53,7 @@ async def test_tools_call_success_returns_factcheck_result(
         return_value={"verdict": "TRUE", "suggestion": None}
     )
 
-    async with AsyncClient(
-        transport=ASGITransport(app=app), base_url="http://test"
-    ) as client:
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
         response = await client.post(
             "/mcp",
             json={
@@ -91,13 +89,9 @@ async def test_tools_call_pipeline_failure_returns_internal_error(
 ):
     """tools/call 파이프라인 실패 시 Internal Error 반환"""
     # Mock 설정: Gemini extraction 실패
-    mock_gemini_service.extract_sentences = AsyncMock(
-        side_effect=Exception("Gemini API timeout")
-    )
+    mock_gemini_service.extract_sentences = AsyncMock(side_effect=Exception("Gemini API timeout"))
 
-    async with AsyncClient(
-        transport=ASGITransport(app=app), base_url="http://test"
-    ) as client:
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
         response = await client.post(
             "/mcp",
             json={
@@ -118,9 +112,7 @@ async def test_tools_call_pipeline_failure_returns_internal_error(
 @pytest.mark.asyncio
 async def test_tools_call_invalid_arguments_returns_error():
     """tools/call 필수 인자 누락 시 Invalid Params 반환"""
-    async with AsyncClient(
-        transport=ASGITransport(app=app), base_url="http://test"
-    ) as client:
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
         response = await client.post(
             "/mcp",
             json={
@@ -144,9 +136,7 @@ async def test_tools_call_invalid_arguments_returns_error():
 @pytest.mark.asyncio
 async def test_tools_call_unknown_tool_returns_error():
     """tools/call 알 수 없는 도구 요청 시 Invalid Params 반환"""
-    async with AsyncClient(
-        transport=ASGITransport(app=app), base_url="http://test"
-    ) as client:
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
         response = await client.post(
             "/mcp",
             json={


### PR DESCRIPTION
## 🎫 관련 이슈 (Related Issue)
- Closes #14 

## 🛠️ 작업 내용 (Description)
- **AS-IS**: 전역 에러 핸들러가 없어 비즈니스 로직 외의 에러(파싱 에러, 미들웨어 에러 등) 발생 시 FastAPI 기본 HTML/Text 응답이 반환될 수 있었으며, 로그가 단순 텍스트(`print` 등)로 출력되어 디버깅이 어려웠습니다.
- **TO-BE**:
    - **전역 에러 핸들러 도입**: 모든 예외를 포착하여 항상 규격화된 `JSON-RPC` 포맷으로 응답합니다.
    - **구조화된 로깅 (Structured Logging)**: `structlog`를 도입하여 모든 로그를 JSON 포맷으로 출력, `timestamp`, `level`, `tool_name` 등의 메타데이터를 자동으로 포함합니다.
    - **보안 강화**: `ENVIRONMENT` 환경변수(`dev`, `prod`)에 따라 에러 응답에 `Traceback` 포함 여부를 제어합니다 (운영 환경 노출 방지).
    - **코드 품질 개선**: `src/mcp/handlers.py`의 매직 리터럴(`"factcheck"`)을 상수로 추출하고, `config.py`의 환경변수 검증을 강화했습니다.

## ✅ 체크리스트 (Self Checklist)

**기본 확인**
- [x] 내 코드를 스스로 리뷰했나요? (오타, 불필요한 주석 제거)
- [x] 로컬에서 빌드 및 테스트가 통과했나요?
- [x] (필요 시) 관련 문서나 API 명세서를 업데이트했나요?
    - `.env.example` 업데이트 (ENVIRONMENT 변수 추가)

**안정성 및 배포**
- [x] 환경변수(.env) 변경 사항이 있다면 공유했나요?
    - `ENVIRONMENT` (default: `dev`) 추가됨.
- [x] 민감한 정보(API Key 등)가 코드에 포함되지 않았나요?

## 🧪 테스트 방법 (How to Test)
1. `.env` 파일에 `ENVIRONMENT=dev` 설정 확인.
2. `poetry run pytest tests/integration/global_exception_spec.py` 실행하여 에러 핸들링 로직 검증.
3. 서버 실행:
   ```bash
   PYTHONPATH=src poetry run uvicorn main:app --reload
   ```
4. **테스트 요청 (curl)**:
   새 터미널에서 다음 명령어로 에러 상황을 유도하여 JSON 응답과 서버 로그를 확인합니다.
   ```bash
   # 존재하지 않는 도구 호출 (에러 응답 확인)
   curl -X POST http://localhost:8000/mcp \
     -H "Content-Type: application/json" \
     -d '{
       "jsonrpc": "2.0",
       "id": 1,
       "method": "tools/call",
       "params": {
         "name": "unknown-tool",
         "arguments": {}
       }
     }' | json_pp
   ```
