### PR TITLE
feat: Whitelist→Graylist Fallback 검색 구현 (#16)

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2396,4 +2396,4 @@ cffi = ["cffi (>=1.17,<2.0) ; platform_python_implementation != \"PyPy\" and pyt
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.13,<4.0"
-content-hash = "aa4e3a278e6cd942e9314c3f7fa7109d5696fa0f0f499296de0590157b76420b"
+content-hash = "fe7ce1be3dee7c5c7d1237a4ee959606c2286fd1f611208f2243175eb8789d6c"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,8 @@ dependencies = [
     "tavily-python (>=0.7.17,<0.8.0)",
     "pydantic (>=2.12.5,<3.0.0)",
     "pydantic-settings (>=2.9.1,<3.0.0)",
-    "structlog (>=25.5.0,<26.0.0)"
+    "structlog (>=25.5.0,<26.0.0)",
+    "tenacity (>=9.1.2,<10.0.0)"
 ]
 
 [tool.commitizen]

--- a/scripts/test_fallback_e2e.py
+++ b/scripts/test_fallback_e2e.py
@@ -1,0 +1,100 @@
+"""E2E test specific for Fallback Logic verification
+
+사용법: PYTHONPATH=src poetry run python scripts/test_fallback_e2e.py
+"""
+
+import asyncio
+from urllib.parse import urlparse
+
+from dotenv import load_dotenv
+
+from graph.state import PipelineSentence
+from graph.workflow import create_graph
+
+_ = load_dotenv()
+
+
+def extract_domain(url: str) -> str:
+    """URL에서 도메인 추출"""
+    try:
+        return urlparse(url).netloc
+    except Exception:
+        return ""
+
+
+async def test_fallback():
+    """Fallback 로직 검증: Whitelist 실패 -> Graylist 자동 전환 확인"""
+
+    # 1. 테스트 입력 (긴 텍스트)
+    test_text = (
+        "지구는 평평하다는 주장이 있습니다. 그러나 과학적으로 지구는 타원형의 구체입니다. "
+        "물은 100도에서 끓습니다. "
+        "아인슈타인은 상대성 이론을 발표했다. "
+        "비타민 C는 감기를 예방한다고 알려져 있습니다. "
+    )
+
+    # 2. 강제 Fallback 유도 설정
+    # 존재하지 않거나 정보가 없을 도메인만 Whitelist에 포함
+    dummy_whitelist = ["example.com", "nonexistent-domain.xyz"]
+
+    print(f"입력 텍스트: {test_text[:50]}...")
+    print(f"설정된 Whitelist: {dummy_whitelist}")
+    print(">>> 1차 검색(Whitelist)은 실패하고 자동으로 2차 검색(Graylist)이 수행되어야 합니다.\n")
+
+    print("파이프라인 실행 중...")
+    graph = create_graph()
+
+    # LangGraph 실행
+    result = await graph.ainvoke(
+        {
+            "original_text": test_text,
+            "whitelist": dummy_whitelist,
+            "blacklist": [],
+            "title": "",
+            "sentences": [],
+        }
+    )
+
+    sentences: list[PipelineSentence] = result["sentences"]
+
+    # 3. 결과 검증 및 출력
+    print("\n[검증 결과]")
+
+    claims = [s for s in sentences if s.get("type") == "claim"]
+    fallback_success_count = 0
+
+    for i, sent in enumerate(claims):
+        print(f"\n--- Claim {i + 1} ---")
+        print(f"텍스트: {sent.get('text')}")
+
+        sources = sent.get("sources", [])
+        print(f"검색된 소스 수: {len(sources)}")
+
+        if not sources:
+            print("❌ 검색 실패 (소스 없음)")
+            continue
+
+        # 소스 도메인 확인
+        found_domains = {extract_domain(src["url"]) for src in sources}
+        print(f"발견된 도메인: {found_domains}")
+
+        # Whitelist에 없는 도메인이 발견되면 Fallback 성공으로 간주
+        is_fallback_triggered = any(d not in dummy_whitelist for d in found_domains)
+
+        if is_fallback_triggered:
+            print("✅ Fallback 동작 확인됨 (Whitelist 외 도메인에서 검색됨)")
+            fallback_success_count += 1
+        else:
+            print("❓ Whitelist 내에서만 검색됨 (Fallback 미발동 혹은 Whitelist 성공)")
+
+    print(f"\n총 Claim 수: {len(claims)}")
+    print(f"Fallback 성공 수: {fallback_success_count}")
+
+    if fallback_success_count > 0:
+        print("\nSUCCESS: Fallback 로직이 정상 동작했습니다.")
+    else:
+        print("\nFAIL: Fallback이 동작하지 않았거나 검색된 소스가 없습니다.")
+
+
+if __name__ == "__main__":
+    asyncio.run(test_fallback())

--- a/src/common/text_utils.py
+++ b/src/common/text_utils.py
@@ -1,0 +1,89 @@
+"""텍스트 처리를 위한 공통 유틸리티 모듈"""
+
+
+def normalize_text(text: str) -> str:
+    """
+    텍스트 정규화: 공백 제거 및 소문자 변환
+    비교(Matching)를 위한 표준 형태로 만듭니다.
+    """
+    return "".join(text.split()).lower()
+
+
+def find_fuzzy_indices(original: str, target: str, start_offset: int = 0) -> tuple[int, int]:
+    """
+    원본 텍스트(original) 내에서 타겟 텍스트(target)의 위치를 "유연하게" 찾습니다.
+
+    특징:
+    - 공백(띄어쓰기, 탭, 줄바꿈)과 대소문자를 무시하고 매칭합니다.
+    - 매칭된 구간의 '원본' 인덱스(Start, End)를 반환합니다.
+
+    Args:
+        original: 원본 텍스트
+        target: 찾고자 하는 텍스트 (부분 문자열)
+        start_offset: 검색 시작 위치 (기본값 0)
+
+    Returns:
+        (start_index, end_index): 매칭된 구간의 시작과 끝 인덱스.
+        실패 시 (-1, -1) 반환.
+    """
+    if not target:
+        return -1, -1
+
+    target_clean = normalize_text(target)
+    if not target_clean:
+        return -1, -1
+
+    target_len = len(target_clean)
+    original_len = len(original)
+    current_match_count = 0
+    match_start_index = -1
+
+    for i in range(start_offset, original_len):
+        char = original[i]
+
+        if char.isspace():
+            continue
+
+        char_lower = char.lower()
+
+        if char_lower == target_clean[current_match_count]:
+            if current_match_count == 0:
+                match_start_index = i
+
+            current_match_count += 1
+
+            if current_match_count == target_len:
+                return match_start_index, i + 1
+        else:
+            if current_match_count > 0:
+                pass
+
+    return _find_fuzzy_indices_mapping(original, target_clean, start_offset)
+
+
+def _find_fuzzy_indices_mapping(
+    original: str, target_clean: str, start_offset: int
+) -> tuple[int, int]:
+    """
+    내부 구현용: Mapping 테이블 방식
+    Original의 (Clean Index -> Original Index) 매핑을 생성하여 정확한 위치 찾기
+    """
+    clean_to_original_map = []
+
+    for i in range(start_offset, len(original)):
+        char = original[i]
+        if not char.isspace():
+            clean_to_original_map.append(i)
+
+    original_clean = "".join(original[idx].lower() for idx in clean_to_original_map)
+    clean_start = original_clean.find(target_clean)
+
+    if clean_start == -1:
+        return -1, -1
+
+    clean_end = clean_start + len(target_clean) - 1
+
+    original_start_index = clean_to_original_map[clean_start]
+    original_end_index = clean_to_original_map[clean_end] + 1
+
+    return original_start_index, original_end_index

--- a/src/graph/nodes/search.py
+++ b/src/graph/nodes/search.py
@@ -10,22 +10,22 @@ async def search_node(sentence: PipelineSentence) -> PipelineSentence:
 
     service = get_tavily_service()
 
-    # 1. 1차 검색 (Whitelist)
-    sources = await service.search(
-        query=sentence["text"],
-        include_domains=sentence.get("whitelist", []),
-        exclude_domains=sentence.get("blacklist", []),
-        max_results=3,
-    )
+    search_strategies = [
+        sentence.get("whitelist", []),
+        None,
+    ]
 
-    if not sources:
-        # 2. 2차 검색 (Fallback: Graylist) - 결과가 0건일 때
+    sources = []
+    for domains in search_strategies:
         sources = await service.search(
             query=sentence["text"],
-            include_domains=None,  # Whitelist 해제
+            include_domains=domains,
             exclude_domains=sentence.get("blacklist", []),
             max_results=3,
         )
+
+        if sources:
+            break
 
     sentence["sources"] = sources
 

--- a/src/graph/nodes/search.py
+++ b/src/graph/nodes/search.py
@@ -8,20 +8,24 @@ async def search_node(sentence: PipelineSentence) -> PipelineSentence:
     claim 문장에 대해 TavilyService를 통해 관련 소스를 검색합니다.
     """
 
-    # 1. retry_count 증가 (재검색인 경우)
-    if "retry_count" in sentence:
-        # sources가 이미 채워져 있으면 재시도임
-        if "sources" in sentence and sentence["sources"]:
-            sentence["retry_count"] += 1
-
-    # 2. TavilyService를 통한 검색 수행 (싱글톤 인스턴스 사용)
     service = get_tavily_service()
+
+    # 1. 1차 검색 (Whitelist)
     sources = await service.search(
         query=sentence["text"],
         include_domains=sentence.get("whitelist", []),
         exclude_domains=sentence.get("blacklist", []),
-        max_results=5,
+        max_results=3,
     )
+
+    if not sources:
+        # 2. 2차 검색 (Fallback: Graylist) - 결과가 0건일 때
+        sources = await service.search(
+            query=sentence["text"],
+            include_domains=None,  # Whitelist 해제
+            exclude_domains=sentence.get("blacklist", []),
+            max_results=3,
+        )
 
     sentence["sources"] = sources
 

--- a/src/graph/nodes/verification.py
+++ b/src/graph/nodes/verification.py
@@ -16,4 +16,8 @@ async def verification_node(sentence: PipelineSentence) -> PipelineSentence:
     sentence["verdict"] = result["verdict"]
     sentence["suggestion"] = result.get("suggestion")
 
+    # 검증 실패(FALSE) 시 재시도 횟수 증가 (Loop 종료 조건용)
+    if sentence["verdict"] == "FALSE":
+        sentence["retry_count"] = sentence.get("retry_count", 0) + 1
+
     return sentence

--- a/src/services/llm.py
+++ b/src/services/llm.py
@@ -12,7 +12,11 @@ from tenacity import (
     wait_exponential,
 )
 
+from common.logger import get_logger
+from common.text_utils import find_fuzzy_indices
 from services.prompts import EXTRACTION_PROMPT, VERIFICATION_PROMPT
+
+log = get_logger(__name__)
 
 
 class ExtractedSentence(BaseModel):
@@ -91,14 +95,16 @@ class GeminiService:
         for s in result.sentences:
             sentence_dict = s.model_dump(exclude_none=True)
 
-            # 원본 텍스트에서 문장 위치 찾기
-            idx = text.find(s.text, search_start)
-            if idx != -1:
-                sentence_dict["start_index"] = idx
-                sentence_dict["end_index"] = idx + len(s.text)
-                search_start = idx + len(s.text)  # 다음 검색 시작점
+            # 원본 텍스트에서 문장 위치 찾기 (Fuzzy Matching)
+            start_idx, end_idx = find_fuzzy_indices(text, s.text, search_start)
+
+            if start_idx != -1:
+                sentence_dict["start_index"] = start_idx
+                sentence_dict["end_index"] = end_idx
+                search_start = end_idx
             else:
-                # 찾지 못한 경우 -1로 표시
+                # 찾지 못함 - 강제 Fallback 처리
+                log.warning("Fuzzy match failed", text=s.text, search_start=search_start)
                 sentence_dict["start_index"] = -1
                 sentence_dict["end_index"] = -1
 

--- a/src/services/llm.py
+++ b/src/services/llm.py
@@ -3,8 +3,14 @@
 from typing import Literal
 
 from google import genai
-from google.genai import types
+from google.genai import errors, types
 from pydantic import BaseModel, Field
+from tenacity import (
+    retry,
+    retry_if_exception_type,
+    stop_after_attempt,
+    wait_exponential,
+)
 
 from services.prompts import EXTRACTION_PROMPT, VERIFICATION_PROMPT
 
@@ -43,6 +49,24 @@ class GeminiService:
         # TODO: 모델명 관리(환경 변수 or 설정 파일)
         self.model = "gemini-2.5-flash-lite"
 
+    @retry(
+        retry=retry_if_exception_type((errors.ServerError, errors.ClientError)),
+        stop=stop_after_attempt(3),
+        wait=wait_exponential(multiplier=1, min=2, max=10),
+    )
+    async def _generate_content(self, contents: str, response_schema: type[BaseModel]):
+        """재시도 로직이 적용된 내부 generate_content 메서드"""
+        config = types.GenerateContentConfig(
+            response_mime_type="application/json",
+            response_schema=response_schema,
+            temperature=0.1,
+        )
+        return await self.client.aio.models.generate_content(
+            model=self.model,
+            contents=contents,
+            config=config,
+        )
+
     async def extract_sentences(self, text: str) -> dict:
         """
         텍스트에서 문장 추출 및 분류
@@ -56,15 +80,7 @@ class GeminiService:
         """
         prompt = EXTRACTION_PROMPT.format(text=text)
 
-        response = await self.client.aio.models.generate_content(
-            model=self.model,
-            contents=prompt,
-            config=types.GenerateContentConfig(
-                response_mime_type="application/json",
-                response_schema=ExtractionResult,
-                temperature=0.1,  # 일관된 분류를 위해 낮은 temperature
-            ),
-        )
+        response = await self._generate_content(prompt, ExtractionResult)
 
         result = ExtractionResult.model_validate_json(response.text)
 
@@ -112,15 +128,7 @@ class GeminiService:
 
         prompt = VERIFICATION_PROMPT.format(claim=claim, sources=sources_text)
 
-        response = await self.client.aio.models.generate_content(
-            model=self.model,
-            contents=prompt,
-            config=types.GenerateContentConfig(
-                response_mime_type="application/json",
-                response_schema=VerificationResult,
-                temperature=0.1,
-            ),
-        )
+        response = await self._generate_content(prompt, VerificationResult)
 
         result = VerificationResult.model_validate_json(response.text)
         return result.model_dump(exclude_none=True)

--- a/src/services/llm_spec.py
+++ b/src/services/llm_spec.py
@@ -214,3 +214,54 @@ async def test_extract_sentences_api_error(mocker):
         await service.extract_sentences("테스트")
 
     assert "rate limit" in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_extract_sentences_fuzzy_match(mocker):
+    """
+    LLM 출력의 공백이 원본과 다르더라도(Fuzzy Matching)
+    extract_sentences가 인덱스를 올바르게 식별하는지 테스트합니다.
+    """
+    # 1. Setup Data
+    original_text = "Hello\nWorld.  This is a   test."
+    # LLM이 줄바꿈을 공백으로 바꾸고, 다중 공백을 하나로 줄여서 반환한다고 가정
+
+    # 2. Mocking _generate_content
+    # 실제 API 호출 대신, 우리가 원하는 결과를 반환하도록 설정
+    mock_llm_result = llm.ExtractionResult(
+        title="Test Title",
+        sentences=[
+            llm.ExtractedSentence(type="claim", text="Hello World."),
+            llm.ExtractedSentence(type="opinion", text="This is a test."),
+        ],
+    )
+
+    mock_api_response = MagicMock()
+    mock_api_response.text = mock_llm_result.model_dump_json()
+
+    mock_client = MagicMock()
+    mock_client.aio.models.generate_content = AsyncMock(return_value=mock_api_response)
+    mocker.patch.object(llm.genai, "Client", return_value=mock_client)
+
+    # 3. Execution
+    service = llm.GeminiService(api_key="test-key")
+    result = await service.extract_sentences(original_text)
+
+    # 4. Verification
+    sentences = result["sentences"]
+    assert len(sentences) == 2
+
+    # 첫 번째 문장: "Hello\nWorld."
+    # 원본: "Hello\nWorld." (0 ~ 12)
+    s1 = sentences[0]
+    assert s1["text"] == "Hello World."  # LLM 반환 텍스트
+    assert s1["start_index"] == 0
+    assert s1["end_index"] == 12
+    assert original_text[s1["start_index"] : s1["end_index"]] == "Hello\nWorld."
+
+    # 두 번째 문장: "  This is a   test."
+    # 앞의 공백 포함 여부에 따라 달라질 수 있으나, find_fuzzy_indices 로직에 따름
+    # "This is a test." -> 원본 "This is a   test." 매칭
+    s2 = sentences[1]
+    assert s2["text"] == "This is a test."
+    assert original_text[s2["start_index"] : s2["end_index"]] == "This is a   test."

--- a/src/services/search.py
+++ b/src/services/search.py
@@ -1,5 +1,7 @@
 """Tavily Search API 서비스 래퍼"""
 
+import asyncio
+
 from tavily import AsyncTavilyClient
 
 from graph.state import Source
@@ -17,13 +19,15 @@ class TavilyService:
             api_key: Tavily API 키
         """
         self.client = AsyncTavilyClient(api_key=api_key)
+        # 동시 요청 제한을 위한 세마포어 (최대 3개)
+        self.semaphore = asyncio.Semaphore(3)
 
     async def search(
         self,
         query: str,
         include_domains: list[str] | None = None,  # whitelist
         exclude_domains: list[str] | None = None,  # blacklist
-        max_results: int = 5,
+        max_results: int = 3,
     ) -> list[Source]:
         """
         웹 검색 수행
@@ -40,12 +44,13 @@ class TavilyService:
         include_domains = include_domains or []
         exclude_domains = exclude_domains or []
 
-        response = await self.client.search(
-            query=query,
-            max_results=max_results,
-            include_domains=include_domains if include_domains else None,
-            exclude_domains=exclude_domains if exclude_domains else None,
-        )
+        async with self.semaphore:
+            response = await self.client.search(
+                query=query,
+                max_results=max_results,
+                include_domains=include_domains if include_domains else None,
+                exclude_domains=exclude_domains if exclude_domains else None,
+            )
 
         sources: list[Source] = []
         for result in response.get("results", []):

--- a/tests/graph/nodes/test_search_fallback.py
+++ b/tests/graph/nodes/test_search_fallback.py
@@ -1,0 +1,85 @@
+from unittest.mock import AsyncMock, call, patch
+
+import pytest
+
+from graph.nodes.search import search_node
+from graph.state import PipelineSentence
+
+
+@pytest.fixture
+def mock_tavily_service():
+    with patch("graph.nodes.search.get_tavily_service") as mock_get:
+        service_mock = AsyncMock()
+        mock_get.return_value = service_mock
+        yield service_mock
+
+
+@pytest.mark.asyncio
+async def test_search_node_whitelist_success(mock_tavily_service):
+    """Scenario 1: Whitelist 검색 성공 -> 1회 호출 후 즉시 반환"""
+    # Given
+    sentence: PipelineSentence = {
+        "text": "test query",
+        "whitelist": ["trusted.com"],
+        "blacklist": ["bad.com"],
+        "type": "claim",
+    }
+    mock_tavily_service.search.return_value = [
+        {"title": "Result 1", "url": "http://trusted.com/1", "snippet": "content"}
+    ]
+
+    # When
+    result = await search_node(sentence)
+
+    # Then
+    mock_tavily_service.search.assert_awaited_once_with(
+        query="test query",
+        include_domains=["trusted.com"],
+        exclude_domains=["bad.com"],
+        max_results=3,
+    )
+    assert len(result["sources"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_search_node_fallback_execution(mock_tavily_service):
+    """Scenario 2: Whitelist 실패(0건) -> Graylist 자동 재검색 (In-Node)"""
+    # Given
+    sentence: PipelineSentence = {
+        "text": "test query",
+        "whitelist": ["trusted.com"],
+        "blacklist": ["bad.com"],
+        "type": "claim",
+    }
+
+    # 순차적 반환 설정: 1차(빈 리스트) -> 2차(결과 있음)
+    mock_tavily_service.search.side_effect = [
+        [],
+        [{"title": "Gray Result", "url": "http://other.com", "snippet": "content"}],
+    ]
+
+    # When
+    result = await search_node(sentence)
+
+    # Then
+    assert mock_tavily_service.search.await_count == 2
+
+    # 호출 순서 및 인자 검증
+    expected_calls = [
+        call(
+            query="test query",
+            include_domains=["trusted.com"],
+            exclude_domains=["bad.com"],
+            max_results=3,
+        ),
+        call(
+            query="test query",
+            include_domains=None,  # 2차는 Whitelist 해제
+            exclude_domains=["bad.com"],
+            max_results=3,
+        ),
+    ]
+    mock_tavily_service.search.assert_has_awaits(expected_calls)
+
+    assert len(result["sources"]) == 1
+    assert result["sources"][0]["title"] == "Gray Result"

--- a/tests/graph/nodes_spec.py
+++ b/tests/graph/nodes_spec.py
@@ -59,27 +59,6 @@ async def test_search_node(mock_tavily_service):
 
 
 @pytest.mark.asyncio
-async def test_search_node_retry(mock_tavily_service):
-    """Search 노드가 재진입 시 retry_count를 증가시키는지 테스트"""
-    sentence: PipelineSentence = {
-        "type": "claim",
-        "text": "테스트 주장",
-        "start_index": 0,
-        "end_index": 5,
-        "retry_count": 0,
-        "sources": [{"title": "Old", "url": "url", "snippet": "old"}],
-    }
-
-    mock_sources = [{"title": "New", "url": "https://new.com", "snippet": "새 결과"}]
-    mock_tavily_service.search = AsyncMock(return_value=mock_sources)
-
-    result = await search.search_node(sentence)
-
-    assert result["retry_count"] == 1  # 증가했어야 함
-    assert "sources" in result  # 검색 다시 수행됨
-
-
-@pytest.mark.asyncio
 async def test_search_node_with_domain_filters(mock_tavily_service):
     """Search 노드가 whitelist/blacklist를 TavilyService에 전달하는지 테스트"""
     sentence: PipelineSentence = {
@@ -103,7 +82,7 @@ async def test_search_node_with_domain_filters(mock_tavily_service):
         query="테스트 주장",
         include_domains=["trusted.com", "reliable.org"],
         exclude_domains=["spam.com"],
-        max_results=5,
+        max_results=3,
     )
 
 


### PR DESCRIPTION
## 🎫 관련 이슈 (Related Issue)
- Closes #16

## 🛠️ 작업 내용 (Description)
### **AS-IS**
- Whitelist(신뢰 도메인) 검색 결과가 0건일 경우, 추가 검색 없이 종료되어 검증 실패로 이어짐
- LLM이 추출한 문장이 원본 텍스트와 띄어쓰기나 특수문자가 조금이라도 다를 경우 위치를 찾지 못함
- 다수의 Claim 검색 요청이 동시에 발생할 때 Tavily API Rate Limit에 걸릴 위험이 있음

### **TO-BE**
- search_node 내부에서 Whitelist 검색 결과가 없으면 자동으로 Graylist 검색을 수행하도록 로직 개선
    - In-Node Strategy Loop 도입
- 공백과 대소문자를 무시하는 Fuzzy Matching 알고리즘 유틸 함수 을 구현 및 적용.
- `asyncio.Semaphore(3)`를 도입하여 동시 실행 쿼리 수를 제한
    - 기본 검색 결과 수(`max_results`)를 3개로 최적화.

## ✅ 체크리스트 (Self Checklist)

**기본 확인**
- [x] 내 코드를 스스로 리뷰했나요? (오타, 불필요한 주석 제거)
- [x] 로컬에서 빌드 및 테스트가 통과했나요?
- [ ] (필요 시) 관련 문서나 API 명세서를 업데이트했나요?

**안정성 및 배포**
- [x] 환경변수(.env) 변경 사항이 있다면 공유했나요? (변경 없음)
- [x] 민감한 정보(API Key 등)가 코드에 포함되지 않았나요?

## 🧪 테스트 방법 (How to Test)
### **Fallback 기능 검증 (E2E API Test)**
   ```bash
   PYTHONPATH=src poetry run python scripts/test_fallback_e2e.py
   ```
* 결과: SUCCESS: Fallback 로직이 정상 동작했습니다. 로그 확인 (Whitelist 실패 -> Graylist 성공)

### 단위 테스트 (Unit Test)
```bash
poetry run pytest tests
```
* 결과: test_search_fallback.py, test_text_utils.py 등 신규 테스트 케이스 통과 확인